### PR TITLE
feat: add browser-based rendering with authentication cookie forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,20 @@ RUN corepack enable pnpm
 # Install dependencies only when needed
 FROM base AS deps
 
+ARG BROWSER=false
+
 # Copy package files
 COPY package.json pnpm-lock.yaml ./
 
 # Install dependencies
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --no-optional
+
+# Skip optional deps (puppeteer/puppeteer-core) by default.
+# When BROWSER=true, also install puppeteer-core for CDP remote connections.
+# puppeteer-core does not download Chromium — that's only the full puppeteer package.
+RUN if [ "$BROWSER" = "true" ]; then \
+    pnpm add puppeteer-core; \
+fi
 RUN rm -rf ~/.npm ~/.pnpm-store
 
 # Build the application
@@ -61,4 +70,4 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["node", "server.js"] 
+CMD ["node", "server.js"]

--- a/app/(app)/recipes/[slug]/page.tsx
+++ b/app/(app)/recipes/[slug]/page.tsx
@@ -186,7 +186,11 @@ const RenderComponent = ({
 				width={imageWidth}
 				height={imageHeight}
 				src={`data:image/bmp;base64,${renders.bitmap.toString("base64")}`}
-				style={{ imageRendering: "pixelated" }}
+				style={{
+					imageRendering: "pixelated",
+					width: imageWidth,
+					height: imageHeight,
+				}}
 				alt={`${title} BMP render`}
 				className="w-full object-cover"
 			/>
@@ -205,10 +209,14 @@ const RenderComponent = ({
 
 		return (
 			<Image
-				width={imageWidth * (useDoubling ? 2 : 1)}
-				height={imageHeight * (useDoubling ? 2 : 1)}
+				width={imageWidth}
+				height={imageHeight}
 				src={`data:image/png;base64,${renders.png.toString("base64")}`}
-				style={{ imageRendering: "pixelated" }}
+				style={{
+					imageRendering: "pixelated",
+					width: imageWidth,
+					height: imageHeight,
+				}}
 				alt={`${title} PNG render`}
 				className="w-full object-cover"
 			/>

--- a/app/(app)/recipes/screens.json
+++ b/app/(app)/recipes/screens.json
@@ -62,7 +62,9 @@
 			"name": "Mangle Kuo",
 			"github": "ghcpuman902"
 		},
-		"renderSettings": {},
+		"renderSettings": {
+			"applyEdgeSnap": false
+		},
 		"version": "0.1.0",
 		"category": "display-components"
 	},

--- a/app/(app)/recipes/screens/bitcoin-price/bitcoin-price.tsx
+++ b/app/(app)/recipes/screens/bitcoin-price/bitcoin-price.tsx
@@ -51,7 +51,7 @@ export default function CryptoPrice({
 
 	return (
 		<PreSatori width={width} height={height}>
-			<div className="flex h-full w-full flex-col bg-white justify-between p-4">
+			<div className="flex h-full w-full flex-col bg-white justify-between p-4 text-black">
 				<div className="flex flex-col">
 					<div className="flex flex-col">
 						<div className="flex items-center justify-between">

--- a/app/(app)/recipes/screens/not-found/not-found.tsx
+++ b/app/(app)/recipes/screens/not-found/not-found.tsx
@@ -11,7 +11,7 @@ export default function NotFoundScreen({
 }) {
 	return (
 		<PreSatori width={width} height={height}>
-			<div className="w-full h-full p-4 bg-white flex flex-col items-center justify-center">
+			<div className="w-full h-full p-4 bg-white flex flex-col items-center justify-center text-black">
 				<div className="text-6xl text-center">Screen Not Found</div>
 				{slug && (
 					<div className="text-xl mt-4 text-center">

--- a/app/(app)/recipes/screens/simple-text/simple-text.tsx
+++ b/app/(app)/recipes/screens/simple-text/simple-text.tsx
@@ -11,7 +11,7 @@ export default function SimpleText({
 }) {
 	return (
 		<PreSatori useDoubling={true} width={width} height={height}>
-			<div className="w-full h-full p-4 bg-white flex flex-col items-center justify-center text-center">
+			<div className="w-full h-full p-4 bg-white flex flex-col items-center justify-center text-center text-black">
 				<div className="text-4xl font-blockkie">
 					Hello World - blockkie font
 				</div>

--- a/app/(app)/recipes/screens/weather/weather.tsx
+++ b/app/(app)/recipes/screens/weather/weather.tsx
@@ -79,7 +79,7 @@ export default function Weather({
 
 	return (
 		<PreSatori width={width} height={height}>
-			<div className="flex flex-col w-full h-full bg-white">
+			<div className="flex flex-col w-full h-full bg-white text-black">
 				<div
 					className={`flex p-4 sm:flex-row items-center justify-between ${isHalfScreen ? "flex-row" : "flex-col sm:flex-row"}`}
 				>

--- a/app/(app)/recipes/screens/wikipedia/wikipedia.tsx
+++ b/app/(app)/recipes/screens/wikipedia/wikipedia.tsx
@@ -107,7 +107,7 @@ export default async function Wikipedia({
 
 	return (
 		<PreSatori useDoubling={true} width={width} height={height}>
-			<div className="flex flex-col w-full h-full bg-white">
+			<div className="flex flex-col w-full h-full bg-white text-black">
 				<div className="flex-none p-4 border-b border-black">
 					<h1 className={` ${isHalfScreen ? "text-4xl" : "text-5xl"}`}>
 						{safeTitle}

--- a/app/(app)/tools/tools-components/image-ditherer/image-ditherer.tsx
+++ b/app/(app)/tools/tools-components/image-ditherer/image-ditherer.tsx
@@ -19,162 +19,17 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
+import {
+	applyDithering as processDithering,
+	DitheringMethod,
+} from "@/utils/image-processing";
 
-// Dithering functions - pure functions that don't depend on component state
-const applyThreshold = (
-	imageData: ImageData,
-	threshold: number,
-	inverted: boolean,
-) => {
-	const data = imageData.data;
-	for (let i = 0; i < data.length; i += 4) {
-		const gray = data[i];
-		const newValue = gray < threshold ? 0 : 255;
-		const finalValue = inverted ? 255 - newValue : newValue;
-		data[i] = data[i + 1] = data[i + 2] = finalValue;
-	}
-};
-
-const applyFloydSteinberg = (imageData: ImageData, inverted: boolean) => {
-	const width = imageData.width;
-	const height = imageData.height;
-	const data = imageData.data;
-	const grayscale = new Array(width * height);
-
-	// Extract grayscale values
-	for (let i = 0; i < data.length; i += 4) {
-		grayscale[i / 4] = data[i];
-	}
-
-	// Apply Floyd-Steinberg dithering
-	for (let y = 0; y < height; y++) {
-		for (let x = 0; x < width; x++) {
-			const index = y * width + x;
-			const oldPixel = grayscale[index];
-			const newPixel = oldPixel < 128 ? 0 : 255;
-			grayscale[index] = newPixel;
-			const error = oldPixel - newPixel;
-
-			if (x + 1 < width) grayscale[index + 1] += (error * 7) / 16;
-			if (y + 1 < height && x > 0)
-				grayscale[index + width - 1] += (error * 3) / 16;
-			if (y + 1 < height) grayscale[index + width] += (error * 5) / 16;
-			if (y + 1 < height && x + 1 < width)
-				grayscale[index + width + 1] += (error * 1) / 16;
-		}
-	}
-
-	// Update image data
-	for (let i = 0; i < data.length; i += 4) {
-		const value = inverted ? 255 - grayscale[i / 4] : grayscale[i / 4];
-		data[i] = data[i + 1] = data[i + 2] = value;
-	}
-};
-
-const applyAtkinson = (imageData: ImageData, inverted: boolean) => {
-	const width = imageData.width;
-	const height = imageData.height;
-	const data = imageData.data;
-	const grayscale = new Array(width * height);
-
-	// Extract grayscale values
-	for (let i = 0; i < data.length; i += 4) {
-		grayscale[i / 4] = data[i];
-	}
-
-	// Apply Atkinson dithering
-	for (let y = 0; y < height; y++) {
-		for (let x = 0; x < width; x++) {
-			const index = y * width + x;
-			const oldPixel = grayscale[index];
-			const newPixel = oldPixel < 128 ? 0 : 255;
-			grayscale[index] = newPixel;
-			const error = Math.floor((oldPixel - newPixel) / 8);
-
-			if (x + 1 < width) grayscale[index + 1] += error;
-			if (x + 2 < width) grayscale[index + 2] += error;
-			if (y + 1 < height && x - 1 >= 0) grayscale[index + width - 1] += error;
-			if (y + 1 < height) grayscale[index + width] += error;
-			if (y + 1 < height && x + 1 < width)
-				grayscale[index + width + 1] += error;
-			if (y + 2 < height) grayscale[index + width * 2] += error;
-		}
-	}
-
-	// Update image data
-	for (let i = 0; i < data.length; i += 4) {
-		const value = inverted ? 255 - grayscale[i / 4] : grayscale[i / 4];
-		data[i] = data[i + 1] = data[i + 2] = value;
-	}
-};
-
-const applyBayer = (
-	imageData: ImageData,
-	patternSize: number,
-	inverted: boolean,
-) => {
-	const width = imageData.width;
-	const height = imageData.height;
-	const data = imageData.data;
-
-	// Bayer matrices for different sizes
-	const bayerMatrix: Record<number, number[][]> = {
-		2: [
-			[0, 2],
-			[3, 1],
-		],
-		4: [
-			[0, 8, 2, 10],
-			[12, 4, 14, 6],
-			[3, 11, 1, 9],
-			[15, 7, 13, 5],
-		],
-		8: [
-			[0, 32, 8, 40, 2, 34, 10, 42],
-			[48, 16, 56, 24, 50, 18, 58, 26],
-			[12, 44, 4, 36, 14, 46, 6, 38],
-			[60, 28, 52, 20, 62, 30, 54, 22],
-			[3, 35, 11, 43, 1, 33, 9, 41],
-			[51, 19, 59, 27, 49, 17, 57, 25],
-			[15, 47, 7, 39, 13, 45, 5, 37],
-			[63, 31, 55, 23, 61, 29, 53, 21],
-		],
-	};
-
-	// Use the closest available matrix size
-	const matrixSize = patternSize <= 2 ? 2 : patternSize <= 4 ? 4 : 8;
-	const matrix = bayerMatrix[matrixSize];
-	const matrixLength = matrix.length;
-
-	// Normalize the matrix values to 0-255 range
-	const normalizedMatrix = matrix.map((row) =>
-		row.map((val) => Math.floor((val * 255) / (matrixLength * matrixLength))),
-	);
-
-	// Apply Bayer dithering
-	for (let y = 0; y < height; y++) {
-		for (let x = 0; x < width; x++) {
-			const index = (y * width + x) * 4;
-			const gray = data[index];
-			const matrixX = x % matrixLength;
-			const matrixY = y % matrixLength;
-			const threshold = normalizedMatrix[matrixY][matrixX];
-			const newValue = gray < threshold ? 0 : 255;
-			const finalValue = inverted ? 255 - newValue : newValue;
-			data[index] = data[index + 1] = data[index + 2] = finalValue;
-		}
-	}
-};
-
-const applyRandom = (imageData: ImageData, inverted: boolean) => {
-	const data = imageData.data;
-	for (let i = 0; i < data.length; i += 4) {
-		const gray = data[i];
-		const randomThreshold = Math.random() * 255;
-		const newValue = gray < randomThreshold ? 0 : 255;
-		const finalValue = inverted ? 255 - newValue : newValue;
-		data[i] = data[i + 1] = data[i + 2] = finalValue;
-	}
+const METHOD_MAP: Record<string, DitheringMethod> = {
+	threshold: DitheringMethod.THRESHOLD,
+	floydSteinberg: DitheringMethod.FLOYD_STEINBERG,
+	atkinson: DitheringMethod.ATKINSON,
+	bayer: DitheringMethod.BAYER,
+	random: DitheringMethod.RANDOM,
 };
 
 export default function ImageDitherer() {
@@ -278,37 +133,32 @@ export default function ImageDitherer() {
 
 		// Get the pre-processed image data for dithering
 		const processedImageData = tempCtx.getImageData(0, 0, width, height);
+		const { data: processedData } = processedImageData;
 
-		// Apply selected dithering method
-		switch (ditheringMethod) {
-			case "threshold":
-				applyThreshold(processedImageData, threshold[0], inverted);
-				break;
-			case "floydSteinberg":
-				applyFloydSteinberg(processedImageData, inverted);
-				break;
-			case "atkinson":
-				applyAtkinson(processedImageData, inverted);
-				break;
-			case "bayer":
-				applyBayer(processedImageData, patternSize[0], inverted);
-				break;
-			case "random":
-				applyRandom(processedImageData, inverted);
-				break;
+		// Extract single-channel grayscale for image-processing functions
+		const grayscaleData = new Uint8Array(width * height);
+		for (let i = 0; i < width * height; i++) {
+			grayscaleData[i] = processedData[i * 4];
+		}
+
+		const bayerSize = (patternSize[0] <= 2 ? 2 : patternSize[0] <= 4 ? 4 : 8) as 2 | 4 | 8;
+		const method = METHOD_MAP[ditheringMethod] ?? DitheringMethod.FLOYD_STEINBERG;
+		const dithered = processDithering(method, grayscaleData, {
+			width,
+			height,
+			threshold: threshold[0],
+			bayerPatternSize: bayerSize,
+		});
+
+		// Write result back to ImageData with optional inversion
+		for (let i = 0; i < width * height; i++) {
+			const value = inverted ? 255 - dithered[i] : dithered[i];
+			processedData[i * 4] = processedData[i * 4 + 1] = processedData[i * 4 + 2] = value;
 		}
 
 		// Put the processed image data back
 		ctx.putImageData(processedImageData, 0, 0);
-	}, [
-		originalImage,
-		ditheringMethod,
-		brightness,
-		contrast,
-		threshold,
-		patternSize,
-		inverted,
-	]);
+	}, [originalImage, ditheringMethod, brightness, contrast, threshold, patternSize, inverted]);
 
 	// Function to convert canvas to BMP and download
 	const downloadAsBMP = () => {
@@ -521,7 +371,7 @@ export default function ImageDitherer() {
 										<SelectValue placeholder="Select dithering method" />
 									</SelectTrigger>
 									<SelectContent>
-										<SelectItem value="threshold">Simple Threshold</SelectItem>
+										<SelectItem value="threshold">Threshold</SelectItem>
 										<SelectItem value="floydSteinberg">
 											Floyd-Steinberg
 										</SelectItem>

--- a/app/(app)/tools/tools-components/image-ditherer/image-ditherer.tsx
+++ b/app/(app)/tools/tools-components/image-ditherer/image-ditherer.tsx
@@ -141,8 +141,12 @@ export default function ImageDitherer() {
 			grayscaleData[i] = processedData[i * 4];
 		}
 
-		const bayerSize = (patternSize[0] <= 2 ? 2 : patternSize[0] <= 4 ? 4 : 8) as 2 | 4 | 8;
-		const method = METHOD_MAP[ditheringMethod] ?? DitheringMethod.FLOYD_STEINBERG;
+		const bayerSize = (patternSize[0] <= 2 ? 2 : patternSize[0] <= 4 ? 4 : 8) as
+			| 2
+			| 4
+			| 8;
+		const method =
+			METHOD_MAP[ditheringMethod] ?? DitheringMethod.FLOYD_STEINBERG;
 		const dithered = processDithering(method, grayscaleData, {
 			width,
 			height,
@@ -153,12 +157,23 @@ export default function ImageDitherer() {
 		// Write result back to ImageData with optional inversion
 		for (let i = 0; i < width * height; i++) {
 			const value = inverted ? 255 - dithered[i] : dithered[i];
-			processedData[i * 4] = processedData[i * 4 + 1] = processedData[i * 4 + 2] = value;
+			processedData[i * 4] =
+				processedData[i * 4 + 1] =
+				processedData[i * 4 + 2] =
+					value;
 		}
 
 		// Put the processed image data back
 		ctx.putImageData(processedImageData, 0, 0);
-	}, [originalImage, ditheringMethod, brightness, contrast, threshold, patternSize, inverted]);
+	}, [
+		originalImage,
+		ditheringMethod,
+		brightness,
+		contrast,
+		threshold,
+		patternSize,
+		inverted,
+	]);
 
 	// Function to convert canvas to BMP and download
 	const downloadAsBMP = () => {

--- a/app/(render)/recipes/[slug]/preview/layout.tsx
+++ b/app/(render)/recipes/[slug]/preview/layout.tsx
@@ -7,7 +7,11 @@ export default function RecipePreviewLayout({
 }) {
 	return (
 		<>
-			<style>{"nextjs-portal{display:none}"}</style>
+			<style>{`
+				nextjs-portal { display: none; }
+				::-webkit-scrollbar { display: none !important; }
+				* { scrollbar-width: none !important; -ms-overflow-style: none !important; }
+			`}</style>
 			<Suspense fallback={<span>Rendering recipe...</span>}>
 				{children}
 			</Suspense>

--- a/app/(render)/recipes/[slug]/preview/layout.tsx
+++ b/app/(render)/recipes/[slug]/preview/layout.tsx
@@ -1,0 +1,16 @@
+import { Suspense, type ReactNode } from "react";
+
+export default function RecipePreviewLayout({
+	children,
+}: {
+	children: ReactNode;
+}) {
+	return (
+		<>
+			<style>{"nextjs-portal{display:none}"}</style>
+			<Suspense fallback={<span>Rendering recipe...</span>}>
+				{children}
+			</Suspense>
+		</>
+	);
+}

--- a/app/(render)/recipes/[slug]/preview/page.tsx
+++ b/app/(render)/recipes/[slug]/preview/page.tsx
@@ -1,0 +1,47 @@
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import {
+	fetchRecipeComponent,
+	fetchRecipeConfig,
+	fetchRecipeProps,
+} from "@/lib/recipes/recipe-renderer";
+
+export default async function RecipePreviewPage({
+	params,
+	searchParams,
+}: {
+	params: Promise<{ slug: string }>;
+	searchParams: Promise<{ width?: string; height?: string }>;
+}) {
+	// Access headers to mark route as dynamic and allow time-based operations
+	headers();
+	const { slug } = await params;
+	const { width: widthParam, height: heightParam } = await searchParams;
+
+	const config = fetchRecipeConfig(slug);
+
+	if (!config) {
+		notFound();
+	}
+
+	const component = await fetchRecipeComponent(slug);
+
+	if (!component) {
+		notFound();
+	}
+
+	const Component = component;
+	const props = await fetchRecipeProps(slug, config);
+
+	// Apply width/height from query params if provided (for browser rendering)
+	const width = widthParam ? Number.parseInt(widthParam, 10) : undefined;
+	const height = heightParam ? Number.parseInt(heightParam, 10) : undefined;
+
+	const propsWithDimensions = {
+		...props,
+		...(width !== undefined && !Number.isNaN(width) && { width }),
+		...(height !== undefined && !Number.isNaN(height) && { height }),
+	};
+
+	return <Component {...propsWithDimensions} />;
+}

--- a/app/api/bitmap/[[...slug]]/route.ts
+++ b/app/api/bitmap/[[...slug]]/route.ts
@@ -45,11 +45,15 @@ export async function GET(
 			? recipeSlug
 			: "simple-text";
 
+		// Extract cookie header to forward to browser renderer
+		const cookieHeader = req.headers.get("cookie");
+
 		const recipeBuffer = await renderRecipeBitmap(
 			recipeId,
 			validWidth,
 			validHeight,
 			grayscaleLevels,
+			cookieHeader || undefined,
 		);
 
 		if (
@@ -84,6 +88,7 @@ const renderRecipeBitmap = cache(
 		width: number,
 		height: number,
 		grayscaleLevels: number = 2,
+		cookies?: string,
 	) => {
 		const { config, Component, props, element } = await buildRecipeElement({
 			slug: recipeId,
@@ -106,6 +111,7 @@ const renderRecipeBitmap = cache(
 			imageHeight: height,
 			formats: ["bitmap"],
 			grayscale: grayscaleLevels,
+			cookies,
 		});
 
 		return renders.bitmap ?? Buffer.from([]);

--- a/docker-compose.browser.yml
+++ b/docker-compose.browser.yml
@@ -1,0 +1,28 @@
+services:
+  byos-next:
+    build:
+      context: .
+      args:
+        BROWSER: "true"
+    image: byos-next-browser
+    environment:
+      - BROWSER_URL=http://127.0.0.1:9222
+      - REACT_RENDERER=browser
+    networks:
+      - byos_network
+
+  chrome:
+    image: zenika/alpine-chrome
+    network_mode: "service:byos-next"
+    command:
+      - "--no-sandbox"
+      - "--disable-setuid-sandbox"
+      - "--disable-dev-shm-usage"
+      - "--disable-gpu"
+      - "--hide-scrollbar"
+      - "--disable-accelerated-2d-canvas"
+      - "--disable-web-security"
+      - "--disable-features=IsolateOrigins,site-per-process"
+      - "--remote-debugging-port=9222"
+      - "--remote-debugging-address=0.0.0.0"
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - "3000:3000"
     environment:
       - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/byos_db?sslmode=disable
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
+      - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:3000}
     depends_on:
       postgres:
         condition: service_healthy

--- a/lib/recipes/recipe-renderer.ts
+++ b/lib/recipes/recipe-renderer.ts
@@ -1,13 +1,11 @@
-import { extractResourceUrls, Renderer } from "@takumi-rs/core";
-import { fetchResources } from "@takumi-rs/helpers";
-import { fromJsx } from "@takumi-rs/helpers/jsx";
-import { ImageResponse } from "next/og";
 import React, { cache, createElement } from "react";
 import NotFoundScreen from "@/app/(app)/recipes/screens/not-found/not-found";
 import screens from "@/app/(app)/recipes/screens.json";
 import { getScreenParams } from "@/app/actions/screens-params";
-import { getTakumiFonts } from "@/lib/fonts";
+import sharp from "sharp";
 import { DitheringMethod, renderBmp } from "@/utils/render-bmp";
+import { renderWithTakumi } from "./renderers/takumi";
+import { renderWithSatori } from "./renderers/satori";
 
 // Logging utility shared between recipe renderers
 export const logger = {
@@ -59,6 +57,7 @@ export type RecipeParamDefinitions = Record<string, RecipeParamDefinition>;
 export type RecipeConfig = (typeof screens)[keyof typeof screens] & {
 	renderSettings?: {
 		doubleSizeForSharperText?: boolean;
+		applyEdgeSnap?: boolean;
 		[key: string]: boolean | string | number | undefined;
 	};
 	params?: RecipeParamDefinitions;
@@ -83,59 +82,12 @@ export const addDimensionsToProps = (
 });
 
 // Get renderer type from environment variable (defaults to "takumi")
-export const getRendererType = (): "takumi" | "satori" => {
+export const getRendererType = (): "takumi" | "satori" | "browser" => {
 	const renderer = process.env.REACT_RENDERER?.toLowerCase();
-	return renderer === "satori" ? "satori" : "takumi";
+	if (renderer === "satori") return "satori";
+	if (renderer === "browser") return "browser";
+	return "takumi";
 };
-
-// Cache the fonts at module initialization
-const rendererFonts = getTakumiFonts();
-
-// Initialize Takumi renderer
-
-const takumiRenderer = new Renderer({ fonts: rendererFonts });
-
-/**
- * Render React element using Takumi
- */
-async function renderWithTakumi(
-	element: React.ReactElement,
-	width: number,
-	height: number,
-): Promise<Buffer> {
-	const node = await fromJsx(element);
-
-	// Extract and fetch external image resources
-	const urls = extractResourceUrls(node);
-	const fetchedResources = urls.length > 0 ? await fetchResources(urls) : [];
-
-	const png = await takumiRenderer.render(node, {
-		width,
-		height,
-		format: "png",
-		fetchedResources,
-	});
-	return Buffer.from(png);
-}
-
-async function renderWithSatori(
-	element: React.ReactElement,
-	width: number,
-	height: number,
-): Promise<Buffer> {
-	const imageOptions = {
-		width: width,
-		height: height,
-		fonts: rendererFonts,
-		shapeRendering: 1,
-		textRendering: 0,
-		imageRendering: 1,
-		debug: false,
-	};
-	const pngResponse = await new ImageResponse(element, imageOptions);
-	const pngBuffer = await pngResponse.arrayBuffer();
-	return Buffer.from(pngBuffer);
-}
 
 export const fetchRecipeConfig = cache((slug: string): RecipeConfig | null => {
 	const config = screens[slug as keyof typeof screens];
@@ -275,74 +227,74 @@ export const renderRecipeOutputs = cache(
 		grayscale,
 	}: RenderOptions): Promise<RenderResults> => {
 		const results = getDefaultRenderResults();
-		const imageOptions = getRecipeImageOptions(config, imageWidth, imageHeight);
+		const needsPng = formats.includes("png");
+		const needsBitmap = formats.includes("bitmap");
+
+		if (!needsPng && !needsBitmap) return results;
+
 		const rendererType = getRendererType();
 
-		const tasks: Array<
-			Promise<{ key: keyof RenderResults; value: Buffer | null }>
-		> = [];
-
-		if (formats.includes("bitmap")) {
-			tasks.push(
-				(async () => {
-					try {
-						const element = createElement(Component, props);
-						const png =
-							rendererType === "satori"
-								? await renderWithSatori(
-										element,
-										imageOptions.width,
-										imageOptions.height,
-									)
-								: await renderWithTakumi(
-										element,
-										imageOptions.width,
-										imageOptions.height,
-									);
-						const buffer = await renderBmp(png, {
-							ditheringMethod: DitheringMethod.FLOYD_STEINBERG,
-							width: imageWidth,
-							height: imageHeight,
-							...(grayscale !== undefined && { grayscale }),
-						});
-						return { key: "bitmap", value: buffer };
-					} catch (error) {
-						logger.error(`Error generating bitmap for ${slug}:`, error);
-						return { key: "bitmap", value: null };
-					}
-				})(),
-			);
+		// Render PNG once — reused for both png and bitmap outputs
+		const imageOptions = getRecipeImageOptions(config, imageWidth, imageHeight);
+		let png: Buffer;
+		try {
+			if (rendererType === "browser") {
+				const { renderWithBrowser } = await import("./renderers/browser").catch(
+					() => {
+						throw new Error(
+							"Browser renderer requires one of: " +
+								"(1) BROWSER_WS_ENDPOINT for a remote Chrome container, " +
+								"(2) puppeteer-core + CHROME_EXECUTABLE_PATH for a local Chrome install, " +
+								"(3) puppeteer for bundled Chrome (pnpm add puppeteer).",
+						);
+					},
+				);
+				const scaleFactor = imageOptions.width / imageWidth;
+				png = await renderWithBrowser(
+					slug,
+					imageWidth,
+					imageHeight,
+					scaleFactor,
+				);
+			} else {
+				const element = createElement(Component, props);
+				png =
+					rendererType === "satori"
+						? await renderWithSatori(
+								element,
+								imageOptions.width,
+								imageOptions.height,
+							)
+						: await renderWithTakumi(
+								element,
+								imageOptions.width,
+								imageOptions.height,
+							);
+			}
+		} catch (error) {
+			logger.error(`Error rendering PNG for ${slug}:`, error);
+			return results;
 		}
 
-		if (formats.includes("png")) {
-			tasks.push(
-				(async () => {
-					try {
-						const element = createElement(Component, props);
-						const pngBuffer =
-							rendererType === "satori"
-								? await renderWithSatori(
-										element,
-										imageOptions.width,
-										imageOptions.height,
-									)
-								: await renderWithTakumi(
-										element,
-										imageOptions.width,
-										imageOptions.height,
-									);
-						return { key: "png", value: pngBuffer };
-					} catch (error) {
-						logger.error(`Error generating PNG for ${slug}:`, error);
-						return { key: "png", value: null };
-					}
-				})(),
-			);
+		if (needsPng) {
+			results.png =
+				imageOptions.width !== imageWidth
+					? await sharp(png).resize(imageWidth, imageHeight).png().toBuffer()
+					: png;
 		}
 
-		const completed = await Promise.all(tasks);
-		for (const { key, value } of completed) {
-			results[key] = value as never;
+		if (needsBitmap) {
+			try {
+				results.bitmap = await renderBmp(png, {
+					ditheringMethod: DitheringMethod.FLOYD_STEINBERG,
+					width: imageWidth,
+					height: imageHeight,
+					applyEdgeSnap: config?.renderSettings?.applyEdgeSnap ?? true,
+					...(grayscale !== undefined && { grayscale }),
+				});
+			} catch (error) {
+				logger.error(`Error generating bitmap for ${slug}:`, error);
+			}
 		}
 
 		return results;

--- a/lib/recipes/recipe-renderer.ts
+++ b/lib/recipes/recipe-renderer.ts
@@ -203,6 +203,7 @@ type RenderOptions = {
 	imageHeight: number;
 	formats?: RenderFormats;
 	grayscale?: number; // Number of gray levels: 2, 4, or 16
+	cookies?: string; // Cookie header to forward to browser renderer
 };
 
 type RenderResults = {
@@ -225,6 +226,7 @@ export const renderRecipeOutputs = cache(
 		imageHeight,
 		formats = ["bitmap", "png"],
 		grayscale,
+		cookies,
 	}: RenderOptions): Promise<RenderResults> => {
 		const results = getDefaultRenderResults();
 		const needsPng = formats.includes("png");
@@ -243,7 +245,7 @@ export const renderRecipeOutputs = cache(
 					() => {
 						throw new Error(
 							"Browser renderer requires one of: " +
-								"(1) BROWSER_WS_ENDPOINT for a remote Chrome container, " +
+								"(1) puppeteer-core + BROWSER_URL or BROWSER_WS_ENDPOINT for a remote Chrome container, " +
 								"(2) puppeteer-core + CHROME_EXECUTABLE_PATH for a local Chrome install, " +
 								"(3) puppeteer for bundled Chrome (pnpm add puppeteer).",
 						);
@@ -255,6 +257,7 @@ export const renderRecipeOutputs = cache(
 					imageWidth,
 					imageHeight,
 					scaleFactor,
+					cookies,
 				);
 			} else {
 				const element = createElement(Component, props);

--- a/lib/recipes/renderers/browser.ts
+++ b/lib/recipes/renderers/browser.ts
@@ -2,11 +2,23 @@
 // Both are optional dependencies — importing their types directly would cause
 // TypeScript to fail in environments where neither package is installed.
 // We only describe the methods we actually use.
+
 interface Browser {
 	connected: boolean;
 	newPage(): Promise<Page>;
 	close(): Promise<void>;
 	disconnect(): void;
+}
+
+interface Cookie {
+	name: string;
+	value: string;
+	domain?: string;
+	path?: string;
+	expires?: number;
+	httpOnly?: boolean;
+	secure?: boolean;
+	sameSite?: "Strict" | "Lax" | "None";
 }
 
 interface Page {
@@ -18,6 +30,7 @@ interface Page {
 		height: number;
 		deviceScaleFactor: number;
 	}): Promise<void>;
+	setCookie(...cookies: Cookie[]): Promise<void>;
 	goto(url: string, options?: { waitUntil: string }): Promise<unknown>;
 	screenshot(options?: { type: string }): Promise<Uint8Array>;
 	close(): Promise<void>;
@@ -40,7 +53,7 @@ async function closeBrowser(): Promise<void> {
 	if (browser) {
 		try {
 			// disconnect() for remote browsers, close() for local ones
-			if (process.env.BROWSER_WS_ENDPOINT) {
+			if (process.env.BROWSER_URL || process.env.BROWSER_WS_ENDPOINT) {
 				browser.disconnect();
 			} else {
 				await browser.close();
@@ -55,29 +68,47 @@ async function closeBrowser(): Promise<void> {
 
 async function getBrowser(): Promise<Browser> {
 	if (!browser || !browser.connected) {
+		const browserUrl = process.env.BROWSER_URL;
 		const wsEndpoint = process.env.BROWSER_WS_ENDPOINT;
 		const executablePath = process.env.CHROME_EXECUTABLE_PATH;
 
-		// Use new Function to prevent the bundler from statically analyzing
-		// these imports — both packages are optional dependencies
-		// biome-ignore lint/security/noNewFunc: intentional bundler bypass for optional deps
-		const unbundledImport = new Function("m", "return import(m)") as
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			(m: string) => Promise<any>;
-
-		if (wsEndpoint) {
-			const { connect } = await unbundledImport("puppeteer-core");
-			browser = await connect({ browserWSEndpoint: wsEndpoint });
+		// puppeteer-core and puppeteer are optional dependencies — types may not
+		// be present in non-browser builds, hence the @ts-ignore comments.
+		// serverExternalPackages in next.config.ts prevents the bundler from
+		// trying to bundle or resolve these at build time.
+		if (browserUrl) {
+			// browserURL lets Puppeteer discover the WebSocket URL via /json/version,
+			// avoiding the need to know Chrome's UUID-based WS path upfront.
+			// biome-ignore lint/ts/noTsIgnoreComment: optional dependency, types absent in non-browser builds
+			// @ts-ignore
+			const { connect } = await import("puppeteer-core");
+			browser = (await connect({
+				browserURL: browserUrl,
+			})) as unknown as Browser;
+		} else if (wsEndpoint) {
+			// biome-ignore lint/ts/noTsIgnoreComment: optional dependency, types absent in non-browser builds
+			// @ts-ignore
+			const { connect } = await import("puppeteer-core");
+			browser = (await connect({
+				browserWSEndpoint: wsEndpoint,
+			})) as unknown as Browser;
 		} else if (executablePath) {
-			const { launch } = await unbundledImport("puppeteer-core");
-			browser = await launch({
+			// biome-ignore lint/ts/noTsIgnoreComment: optional dependency, types absent in non-browser builds
+			// @ts-ignore
+			const { launch } = await import("puppeteer-core");
+			browser = (await launch({
 				headless: true,
 				executablePath,
 				args: BROWSER_OPTIONS,
-			});
+			})) as unknown as Browser;
 		} else {
-			const { launch } = await unbundledImport("puppeteer");
-			browser = await launch({ headless: true, args: BROWSER_OPTIONS });
+			// biome-ignore lint/ts/noTsIgnoreComment: optional dependency, types absent in non-browser builds
+			// @ts-ignore
+			const { launch } = await import("puppeteer");
+			browser = (await launch({
+				headless: true,
+				args: BROWSER_OPTIONS,
+			})) as unknown as Browser;
 		}
 	}
 	// Handle graceful shutdown
@@ -94,11 +125,36 @@ async function getBrowser(): Promise<Browser> {
 	return browser!;
 }
 
+/**
+ * Parse a Cookie header string into individual cookie objects
+ */
+function parseCookies(
+	cookieHeader: string,
+): Array<{ name: string; value: string }> {
+	const cookies: Array<{ name: string; value: string }> = [];
+	const pairs = cookieHeader.split(";");
+
+	for (const pair of pairs) {
+		const trimmed = pair.trim();
+		if (!trimmed) continue;
+
+		const eqIndex = trimmed.indexOf("=");
+		if (eqIndex > 0) {
+			const name = trimmed.substring(0, eqIndex).trim();
+			const value = trimmed.substring(eqIndex + 1).trim();
+			cookies.push({ name, value });
+		}
+	}
+
+	return cookies;
+}
+
 export async function renderWithBrowser(
 	slug: string,
 	width: number,
 	height: number,
 	scale = 1,
+	cookies?: string,
 ): Promise<Buffer> {
 	const port = process.env.PORT || 3000;
 	const baseUrl =
@@ -110,6 +166,22 @@ export async function renderWithBrowser(
 	const page = await b.newPage();
 
 	try {
+		// Forward cookies to the page so it can authenticate
+		if (cookies) {
+			const parsedCookies = parseCookies(cookies);
+			const urlObj = new URL(url);
+			const domain = urlObj.hostname;
+
+			const cookiesToSet = parsedCookies.map((cookie) => ({
+				name: cookie.name,
+				value: cookie.value,
+				domain: domain,
+				path: "/",
+			}));
+
+			await page.setCookie(...cookiesToSet);
+		}
+
 		// Force light mode — headless Chrome can default to dark, which breaks Tailwind v4 color tokens
 		await page.emulateMediaFeatures([
 			{ name: "prefers-color-scheme", value: "light" },

--- a/lib/recipes/renderers/browser.ts
+++ b/lib/recipes/renderers/browser.ts
@@ -1,0 +1,129 @@
+// Minimal local interfaces instead of importing from puppeteer or puppeteer-core.
+// Both are optional dependencies — importing their types directly would cause
+// TypeScript to fail in environments where neither package is installed.
+// We only describe the methods we actually use.
+interface Browser {
+	connected: boolean;
+	newPage(): Promise<Page>;
+	close(): Promise<void>;
+	disconnect(): void;
+}
+
+interface Page {
+	emulateMediaFeatures(
+		features: Array<{ name: string; value: string }>,
+	): Promise<void>;
+	setViewport(viewport: {
+		width: number;
+		height: number;
+		deviceScaleFactor: number;
+	}): Promise<void>;
+	goto(url: string, options?: { waitUntil: string }): Promise<unknown>;
+	screenshot(options?: { type: string }): Promise<Uint8Array>;
+	close(): Promise<void>;
+}
+
+const BROWSER_OPTIONS = [
+	"--disable-dev-shm-usage",
+	"--disable-gpu",
+	"--hide-scrollbar",
+	"--no-sandbox",
+	"--disable-setuid-sandbox",
+	"--disable-accelerated-2d-canvas",
+	"--disable-web-security",
+	"--disable-features=IsolateOrigins,site-per-process",
+];
+
+let browser: Browser | null = null;
+
+async function closeBrowser(): Promise<void> {
+	if (browser) {
+		try {
+			// disconnect() for remote browsers, close() for local ones
+			if (process.env.BROWSER_WS_ENDPOINT) {
+				browser.disconnect();
+			} else {
+				await browser.close();
+			}
+		} catch (error) {
+			console.error("[Browser] Error closing browser:", error);
+		} finally {
+			browser = null;
+		}
+	}
+}
+
+async function getBrowser(): Promise<Browser> {
+	if (!browser || !browser.connected) {
+		const wsEndpoint = process.env.BROWSER_WS_ENDPOINT;
+		const executablePath = process.env.CHROME_EXECUTABLE_PATH;
+
+		// Use new Function to prevent the bundler from statically analyzing
+		// these imports — both packages are optional dependencies
+		// biome-ignore lint/security/noNewFunc: intentional bundler bypass for optional deps
+		const unbundledImport = new Function("m", "return import(m)") as
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(m: string) => Promise<any>;
+
+		if (wsEndpoint) {
+			const { connect } = await unbundledImport("puppeteer-core");
+			browser = await connect({ browserWSEndpoint: wsEndpoint });
+		} else if (executablePath) {
+			const { launch } = await unbundledImport("puppeteer-core");
+			browser = await launch({
+				headless: true,
+				executablePath,
+				args: BROWSER_OPTIONS,
+			});
+		} else {
+			const { launch } = await unbundledImport("puppeteer");
+			browser = await launch({ headless: true, args: BROWSER_OPTIONS });
+		}
+	}
+	// Handle graceful shutdown
+	process.on("exit", closeBrowser);
+	process.on("SIGINT", async () => {
+		await closeBrowser();
+		process.exit(0);
+	});
+	process.on("SIGTERM", async () => {
+		await closeBrowser();
+		process.exit(0);
+	});
+	// biome-ignore lint/style/noNonNullAssertion: guaranteed to be set above
+	return browser!;
+}
+
+export async function renderWithBrowser(
+	slug: string,
+	width: number,
+	height: number,
+	scale = 1,
+): Promise<Buffer> {
+	const port = process.env.PORT || 3000;
+	const baseUrl =
+		process.env.NEXT_PUBLIC_BASE_URL ?? `http://127.0.0.1:${port}`;
+	// Pass original dimensions to the component — it handles scaling internally
+	const url = `${baseUrl}/recipes/${slug}/preview?width=${width}&height=${height}`;
+
+	const b = await getBrowser();
+	const page = await b.newPage();
+
+	try {
+		// Force light mode — headless Chrome can default to dark, which breaks Tailwind v4 color tokens
+		await page.emulateMediaFeatures([
+			{ name: "prefers-color-scheme", value: "light" },
+		]);
+		// Viewport is scaled up so the browser captures the full doubled canvas
+		await page.setViewport({
+			width: width * scale,
+			height: height * scale,
+			deviceScaleFactor: 1,
+		});
+		await page.goto(url, { waitUntil: "networkidle0" });
+		const screenshot = await page.screenshot({ type: "png" });
+		return Buffer.from(screenshot);
+	} finally {
+		await page.close();
+	}
+}

--- a/lib/recipes/renderers/satori.ts
+++ b/lib/recipes/renderers/satori.ts
@@ -1,0 +1,23 @@
+import { ImageResponse } from "next/og";
+import React from "react";
+import { getTakumiFonts } from "@/lib/fonts";
+
+const fonts = getTakumiFonts();
+
+export async function renderWithSatori(
+	element: React.ReactElement,
+	width: number,
+	height: number,
+): Promise<Buffer> {
+	const pngResponse = new ImageResponse(element, {
+		width,
+		height,
+		fonts,
+		shapeRendering: 1,
+		textRendering: 0,
+		imageRendering: 1,
+		debug: false,
+	});
+	const pngBuffer = await pngResponse.arrayBuffer();
+	return Buffer.from(pngBuffer);
+}

--- a/lib/recipes/renderers/satori.ts
+++ b/lib/recipes/renderers/satori.ts
@@ -13,9 +13,6 @@ export async function renderWithSatori(
 		width,
 		height,
 		fonts,
-		shapeRendering: 1,
-		textRendering: 0,
-		imageRendering: 1,
 		debug: false,
 	});
 	const pngBuffer = await pngResponse.arrayBuffer();

--- a/lib/recipes/renderers/takumi.ts
+++ b/lib/recipes/renderers/takumi.ts
@@ -1,0 +1,24 @@
+import { extractResourceUrls, Renderer } from "@takumi-rs/core";
+import { fetchResources } from "@takumi-rs/helpers";
+import { fromJsx } from "@takumi-rs/helpers/jsx";
+import React from "react";
+import { getTakumiFonts } from "@/lib/fonts";
+
+const renderer = new Renderer({ fonts: getTakumiFonts() });
+
+export async function renderWithTakumi(
+	element: React.ReactElement,
+	width: number,
+	height: number,
+): Promise<Buffer> {
+	const node = await fromJsx(element);
+	const urls = extractResourceUrls(node);
+	const fetchedResources = urls.length > 0 ? await fetchResources(urls) : [];
+	const png = await renderer.render(node, {
+		width,
+		height,
+		format: "png",
+		fetchedResources,
+	});
+	return Buffer.from(png);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,34 @@
+import { existsSync } from "fs";
 import type { NextConfig } from "next";
 
+const serverExternalPackages = ["@takumi-rs/core", "@takumi-rs/helpers"];
+
+const browserTracingIncludes = [];
+
+// Detect which optional browser packages are installed at build time.
+if (existsSync("node_modules/puppeteer-core")) {
+  serverExternalPackages.push("puppeteer-core");
+  browserTracingIncludes.push("./node_modules/puppeteer-core/**/*");
+}
+
+if (existsSync("node_modules/puppeteer")) {
+  serverExternalPackages.push("puppeteer");
+  browserTracingIncludes.push("./node_modules/puppeteer/**/*");
+}
+
 const nextConfig: NextConfig = {
-	/* config options here */
-	trailingSlash: false,
-	skipTrailingSlashRedirect: true,
-	cacheComponents: true,
-	output: "standalone",
-	// Mark native modules as external for server components
-	serverExternalPackages: [
-		"@takumi-rs/core",
-		"@takumi-rs/helpers",
-	],
+  /* config options here */
+  trailingSlash: false,
+  skipTrailingSlashRedirect: true,
+  cacheComponents: true,
+  output: "standalone",
+  // Mark native modules as external for server components
+  serverExternalPackages,
+  ...(browserTracingIncludes.length > 0 && {
+    outputFileTracingIncludes: {
+      "/**": browserTracingIncludes,
+    },
+  }),
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
 		"zod": "^4.3.6",
 		"zustand": "^5.0.10"
 	},
+	"optionalDependencies": {
+		"puppeteer": "^24.40.0",
+		"puppeteer-core": "^24.40.0"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.13",
 		"@eslint/eslintrc": "^3.3.3",
@@ -84,6 +88,7 @@
 		"onlyBuiltDependencies": [
 			"@biomejs/biome",
 			"@tailwindcss/oxide",
+			"puppeteer",
 			"unrs-resolver"
 		]
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,9 +113,6 @@ importers:
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
-      puppeteer:
-        specifier: ^24.40.0
-        version: 24.40.0(typescript@5.9.3)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -192,6 +189,13 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+    optionalDependencies:
+      puppeteer:
+        specifier: ^24.40.0
+        version: 24.40.0(typescript@5.9.3)
+      puppeteer-core:
+        specifier: ^24.40.0
+        version: 24.40.0
 
 packages:
 
@@ -5898,6 +5902,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+    optional: true
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6569,7 +6574,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    optional: true
 
   '@ts-morph/common@0.27.0':
     dependencies:
@@ -7018,6 +7024,7 @@ snapshots:
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   ast-types@0.16.1:
     dependencies:
@@ -7035,11 +7042,13 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  b4a@1.8.0: {}
+  b4a@1.8.0:
+    optional: true
 
   balanced-match@1.0.2: {}
 
-  bare-events@2.8.2: {}
+  bare-events@2.8.2:
+    optional: true
 
   bare-fs@4.7.0:
     dependencies:
@@ -7051,12 +7060,15 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+    optional: true
 
-  bare-os@3.8.7: {}
+  bare-os@3.8.7:
+    optional: true
 
   bare-path@3.0.0:
     dependencies:
       bare-os: 3.8.7
+    optional: true
 
   bare-stream@2.13.0(bare-events@2.8.2):
     dependencies:
@@ -7066,10 +7078,12 @@ snapshots:
       bare-events: 2.8.2
     transitivePeerDependencies:
       - react-native-b4a
+    optional: true
 
   bare-url@2.4.0:
     dependencies:
       bare-path: 3.0.0
+    optional: true
 
   base64-js@0.0.8: {}
 
@@ -7077,7 +7091,8 @@ snapshots:
 
   baseline-browser-mapping@2.9.18: {}
 
-  basic-ftp@5.2.2: {}
+  basic-ftp@5.2.2:
+    optional: true
 
   better-auth@1.4.17(next@16.1.6(@babel/core@7.28.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.17.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -7145,7 +7160,8 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
 
-  buffer-crc32@0.2.13: {}
+  buffer-crc32@0.2.13:
+    optional: true
 
   buffer@6.0.3:
     dependencies:
@@ -7199,6 +7215,7 @@ snapshots:
       devtools-protocol: 0.0.1581282
       mitt: 3.0.1
       zod: 3.25.71
+    optional: true
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -7462,7 +7479,8 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-uri-to-buffer@6.0.2: {}
+  data-uri-to-buffer@6.0.2:
+    optional: true
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -7528,6 +7546,7 @@ snapshots:
       ast-types: 0.13.4
       escodegen: 2.1.0
       esprima: 4.0.1
+    optional: true
 
   delaunator@5.0.1:
     dependencies:
@@ -7539,7 +7558,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  devtools-protocol@0.0.1581282: {}
+  devtools-protocol@0.0.1581282:
+    optional: true
 
   diff@3.5.0: {}
 
@@ -7587,6 +7607,7 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+    optional: true
 
   enhanced-resolve@5.18.3:
     dependencies:
@@ -7715,6 +7736,7 @@ snapshots:
       esutils: 2.0.3
     optionalDependencies:
       source-map: 0.6.1
+    optional: true
 
   eslint-config-next@16.1.6(@typescript-eslint/parser@8.48.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -7930,6 +7952,7 @@ snapshots:
       bare-events: 2.8.2
     transitivePeerDependencies:
       - bare-abort-controller
+    optional: true
 
   events@3.3.0: {}
 
@@ -7980,7 +8003,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.1
+      debug: 4.4.3
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -8014,10 +8037,12 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   fast-deep-equal@3.1.3: {}
 
-  fast-fifo@1.3.2: {}
+  fast-fifo@1.3.2:
+    optional: true
 
   fast-glob@3.3.1:
     dependencies:
@@ -8048,6 +8073,7 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+    optional: true
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -8169,6 +8195,7 @@ snapshots:
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.4
+    optional: true
 
   get-stream@6.0.1: {}
 
@@ -8194,6 +8221,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   gifwrap@0.10.1:
     dependencies:
@@ -8292,6 +8320,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -8348,7 +8377,8 @@ snapshots:
 
   interpret@1.4.0: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.1.0:
+    optional: true
 
   ipaddr.js@1.9.1: {}
 
@@ -8708,7 +8738,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lru-cache@7.18.3: {}
+  lru-cache@7.18.3:
+    optional: true
 
   lucide-react@0.563.0(react@19.2.4):
     dependencies:
@@ -8759,7 +8790,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  mitt@3.0.1: {}
+  mitt@3.0.1:
+    optional: true
 
   ms@2.1.3: {}
 
@@ -8800,7 +8832,8 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  netmask@2.1.1: {}
+  netmask@2.1.1:
+    optional: true
 
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -8970,11 +9003,13 @@ snapshots:
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   pac-resolver@7.0.1:
     dependencies:
       degenerator: 5.0.1
       netmask: 2.1.1
+    optional: true
 
   package-manager-detector@1.6.0: {}
 
@@ -9029,7 +9064,8 @@ snapshots:
 
   peek-readable@4.1.0: {}
 
-  pend@1.2.0: {}
+  pend@1.2.0:
+    optional: true
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -9129,7 +9165,8 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress@2.0.3: {}
+  progress@2.0.3:
+    optional: true
 
   prompts@2.4.2:
     dependencies:
@@ -9159,13 +9196,16 @@ snapshots:
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@1.1.0:
+    optional: true
 
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+    optional: true
 
   punycode@2.3.1: {}
 
@@ -9185,6 +9225,7 @@ snapshots:
       - react-native-b4a
       - supports-color
       - utf-8-validate
+    optional: true
 
   puppeteer@24.40.0(typescript@5.9.3):
     dependencies:
@@ -9202,6 +9243,7 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+    optional: true
 
   qs@6.14.1:
     dependencies:
@@ -9401,7 +9443,8 @@ snapshots:
 
   semver@7.7.3: {}
 
-  semver@7.7.4: {}
+  semver@7.7.4:
+    optional: true
 
   send@1.2.1:
     dependencies:
@@ -9579,7 +9622,8 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  smart-buffer@4.2.0: {}
+  smart-buffer@4.2.0:
+    optional: true
 
   socks-proxy-agent@8.0.5:
     dependencies:
@@ -9588,11 +9632,13 @@ snapshots:
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   socks@2.8.7:
     dependencies:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
+    optional: true
 
   sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -9624,6 +9670,7 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+    optional: true
 
   strict-event-emitter@0.5.1: {}
 
@@ -9762,6 +9809,7 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+    optional: true
 
   tar-stream@3.1.8:
     dependencies:
@@ -9773,6 +9821,7 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+    optional: true
 
   teex@1.0.1:
     dependencies:
@@ -9780,12 +9829,14 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+    optional: true
 
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.0
     transitivePeerDependencies:
       - react-native-b4a
+    optional: true
 
   tiny-inflate@1.0.3: {}
 
@@ -9892,7 +9943,8 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typed-query-selector@2.12.1: {}
+  typed-query-selector@2.12.1:
+    optional: true
 
   typescript-eslint@8.48.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -9994,7 +10046,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  webdriver-bidi-protocol@0.4.1: {}
+  webdriver-bidi-protocol@0.4.1:
+    optional: true
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -10061,7 +10114,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.20.0:
+    optional: true
 
   wsl-utils@0.3.1:
     dependencies:
@@ -10099,6 +10153,7 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
+      puppeteer:
+        specifier: ^24.40.0
+        version: 24.40.0(typescript@5.9.3)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -411,24 +414,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.13':
     resolution: {integrity: sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.13':
     resolution: {integrity: sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.13':
     resolution: {integrity: sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.13':
     resolution: {integrity: sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==}
@@ -570,89 +577,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -891,24 +914,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -966,6 +993,11 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@puppeteer/browsers@2.13.0':
+    resolution: {integrity: sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1557,24 +1589,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1624,24 +1660,28 @@ packages:
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@takumi-rs/core-linux-arm64-musl@0.66.5':
     resolution: {integrity: sha512-muPbCfG33evz37UNRDHDEqR9qHWKBhyTJcTD1KG4RDGqjfrX/KoECIf5fb1NJCAsvKVeW/Nd/Ce3iQhPNfAgJA==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@takumi-rs/core-linux-x64-gnu@0.66.5':
     resolution: {integrity: sha512-3iA1aI33B8uYkCQGlA2SwV4oA/nWVuWxYHyKKu3tpvYB500Do2sQxMyRH+6iIV/REDEYCUUW3rw53SaFUuTNKA==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@takumi-rs/core-linux-x64-musl@0.66.5':
     resolution: {integrity: sha512-cPr/JCTy2SIewXWUVOUjp8/FoBEQo+QO3GYGkeiEnqVKAN1IL+ZADjrFW1c7W/rQ+OZePzo7TkTUJ1g5Wwa8kA==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@takumi-rs/core-win32-arm64-msvc@0.66.5':
     resolution: {integrity: sha512-Gmk3o7LDp9jUTd+HKGFlI4mEhTxVbhhnvN1IF/q/Qurz2FhwJjMT3DJMNDm82hEIkBnZ20iekY0QkUqJIcht/Q==}
@@ -1676,6 +1716,9 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
@@ -1811,6 +1854,9 @@ packages:
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
   '@typescript-eslint/eslint-plugin@8.48.0':
     resolution: {integrity: sha512-XxXP5tL1txl13YFtrECECQYeZjBZad4fyd3cFV4a19LkAY/bIp9fev3US4S5fDVV2JaYFiKAZ/GRTOLer+mbyQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1909,41 +1955,49 @@ packages:
     resolution: {integrity: sha512-Cg6xzdkrpltcTPO4At+A79zkC7gPDQIgosJmVV8M104ImB6KZi1MrNXgDYIAfkhUYjPzjNooEDFRAwwPadS7ZA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.10.1':
     resolution: {integrity: sha512-aNeg99bVkXa4lt+oZbjNRPC8ZpjJTKxijg/wILrJdzNyAymO2UC/HUK1UfDjt6T7U5p/mK24T3CYOi3/+YEQSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.10.1':
     resolution: {integrity: sha512-ylz5ojeXrkPrtnzVhpCO+YegG63/aKhkoTlY8PfMfBfLaUG8v6m6iqrL7sBUKdVBgOB4kSTUPt9efQdA/Y3Z/w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.10.1':
     resolution: {integrity: sha512-xcWyhmJfXXOxK7lvE4+rLwBq+on83svlc0AIypfe6x4sMJR+S4oD7n9OynaQShfj2SufPw2KJAotnsNb+4nN2g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.10.1':
     resolution: {integrity: sha512-mW9JZAdOCyorgi1eLJr4gX7xS67WNG9XNPYj5P8VuttK72XNsmdw9yhOO4tDANMgiLXFiSFaiL1gEpoNtRPw/A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.10.1':
     resolution: {integrity: sha512-NZGKhBy6xkJ0k09cWNZz4DnhBcGlhDd3W+j7EYoNvf5TSwj2K6kbmfqTWITEgkvjsMUjm1wsrc4IJaH6VtjyHQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.10.1':
     resolution: {integrity: sha512-VsjgckJ0gNMw7p0d8In6uPYr+s0p16yrT2rvG4v2jUpEMYkpnfnCiALa9SWshbvlGjKQ98Q2x19agm3iFk8w8Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.10.1':
     resolution: {integrity: sha512-idMnajMeejnaFi0Mx9UTLSYFDAOTfAEP7VjXNgxKApso3Eu2Njs0p2V95nNIyFi4oQVGFmIuCkoznAXtF/Zbmw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.10.1':
     resolution: {integrity: sha512-7jyhjIRNFjzlr8x5pth6Oi9hv3a7ubcVYm2GBFinkBQKcFhw4nIs5BtauSNtDW1dPIGrxF0ciynCZqzxMrYMsg==}
@@ -2070,6 +2124,10 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -2094,8 +2152,57 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.0:
+    resolution: {integrity: sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.8.7:
+    resolution: {integrity: sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.0:
+    resolution: {integrity: sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.0:
+    resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
   base64-js@0.0.8:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
@@ -2107,6 +2214,10 @@ packages:
   baseline-browser-mapping@2.9.18:
     resolution: {integrity: sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==}
     hasBin: true
+
+  basic-ftp@5.2.2:
+    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
+    engines: {node: '>=10.0.0'}
 
   better-auth@1.4.17:
     resolution: {integrity: sha512-VmHGQyKsEahkEs37qguROKg/6ypYpNF13D7v/lkbO7w7Aivz0Bv2h+VyUkH4NzrGY0QBKXi1577mGhDCVwp0ew==}
@@ -2200,6 +2311,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
@@ -2244,6 +2358,11 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -2507,6 +2626,10 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2583,6 +2706,10 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
@@ -2596,6 +2723,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devtools-protocol@0.0.1581282:
+    resolution: {integrity: sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==}
 
   diff@3.5.0:
     resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==}
@@ -2651,6 +2781,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
@@ -2709,6 +2842,11 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-config-next@16.1.6:
     resolution: {integrity: sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==}
@@ -2839,6 +2977,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -2872,8 +3013,16 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -2894,6 +3043,9 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3009,6 +3161,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -3023,6 +3179,10 @@ packages:
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   gifwrap@0.10.1:
     resolution: {integrity: sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==}
@@ -3121,6 +3281,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -3184,6 +3348,10 @@ packages:
   interpret@1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
     engines: {node: '>= 0.10'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3529,24 +3697,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3591,6 +3763,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
 
   lucide-react@0.563.0:
     resolution: {integrity: sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==}
@@ -3658,6 +3834,9 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -3695,6 +3874,10 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -3824,6 +4007,14 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
@@ -3892,6 +4083,9 @@ packages:
   peek-readable@4.1.0:
     resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
     engines: {node: '>=8'}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -4016,6 +4210,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -4027,9 +4225,28 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  puppeteer-core@24.40.0:
+    resolution: {integrity: sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==}
+    engines: {node: '>=18'}
+
+  puppeteer@24.40.0:
+    resolution: {integrity: sha512-IxQbDq93XHVVLWHrAkFP7F7iHvb9o0mgfsSIMlhHb+JM+JjM1V4v4MNSQfcRWJopx9dsNOr9adYv0U5fm9BJBQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   qs@6.14.1:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
@@ -4213,6 +4430,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -4294,6 +4516,18 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -4326,6 +4560,9 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -4443,6 +4680,18 @@ packages:
     resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
     engines: {node: '>=6'}
 
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
@@ -4529,6 +4778,9 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typed-query-selector@2.12.1:
+    resolution: {integrity: sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==}
 
   typescript-eslint@8.48.0:
     resolution: {integrity: sha512-fcKOvQD9GUn3Xw63EgiDqhvWJ5jsyZUaekl3KVpGsDJnN46WJTe3jWxtQP9lMZm1LJNkFLlTaWAxK2vUQR+cqw==}
@@ -4622,6 +4874,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -4663,6 +4918,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
@@ -4696,6 +4963,9 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4989,7 +5259,7 @@ snapshots:
       '@babel/parser': 7.28.6
       '@babel/template': 7.28.6
       '@babel/types': 7.28.6
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5613,6 +5883,21 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@puppeteer/browsers@2.13.0':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.7.4
+      tar-fs: 3.1.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6284,6 +6569,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
   '@ts-morph/common@0.27.0':
     dependencies:
       fast-glob: 3.3.3
@@ -6443,6 +6730,11 @@ snapshots:
   '@types/statuses@2.0.6': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 25.0.10
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -6723,6 +7015,10 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -6739,13 +7035,49 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.8.0: {}
+
   balanced-match@1.0.2: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.7.0:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.0(bare-events@2.8.2)
+      bare-url: 2.4.0
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.8.7: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.8.7
+
+  bare-stream@2.13.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.0:
+    dependencies:
+      bare-path: 3.0.0
 
   base64-js@0.0.8: {}
 
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.18: {}
+
+  basic-ftp@5.2.2: {}
 
   better-auth@1.4.17(next@16.1.6(@babel/core@7.28.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.17.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -6813,6 +7145,8 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
 
+  buffer-crc32@0.2.13: {}
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -6859,6 +7193,12 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1581282):
+    dependencies:
+      devtools-protocol: 0.0.1581282
+      mitt: 3.0.1
+      zod: 3.25.71
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -7122,6 +7462,8 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-uri-to-buffer@6.0.2: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -7181,6 +7523,12 @@ snapshots:
 
   defu@6.1.4: {}
 
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
   delaunator@5.0.1:
     dependencies:
       robust-predicates: 3.0.2
@@ -7190,6 +7538,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  devtools-protocol@0.0.1581282: {}
 
   diff@3.5.0: {}
 
@@ -7233,6 +7583,10 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.18.3:
     dependencies:
@@ -7353,6 +7707,14 @@ snapshots:
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-config-next@16.1.6(@typescript-eslint/parser@8.48.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -7563,6 +7925,12 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
@@ -7637,7 +8005,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -7664,6 +8044,10 @@ snapshots:
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -7696,7 +8080,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -7782,6 +8166,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@6.0.1: {}
 
   get-stream@9.0.1:
@@ -7798,6 +8186,14 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.2.2
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   gifwrap@0.10.1:
     dependencies:
@@ -7890,6 +8286,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -7944,6 +8347,8 @@ snapshots:
   internmap@2.0.3: {}
 
   interpret@1.4.0: {}
+
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -8303,6 +8708,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@7.18.3: {}
+
   lucide-react@0.563.0(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -8352,6 +8759,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mitt@3.0.1: {}
+
   ms@2.1.3: {}
 
   msw@2.12.7(@types/node@25.0.10)(typescript@5.9.3):
@@ -8390,6 +8799,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  netmask@2.1.1: {}
 
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -8547,6 +8958,24 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
   package-manager-detector@1.6.0: {}
 
   pako@0.2.9: {}
@@ -8599,6 +9028,8 @@ snapshots:
   path-to-regexp@8.3.0: {}
 
   peek-readable@4.1.0: {}
+
+  pend@1.2.0: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -8698,6 +9129,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  progress@2.0.3: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -8714,7 +9147,61 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
+
+  puppeteer-core@24.40.0:
+    dependencies:
+      '@puppeteer/browsers': 2.13.0
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1581282)
+      debug: 4.4.3
+      devtools-protocol: 0.0.1581282
+      typed-query-selector: 2.12.1
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  puppeteer@24.40.0(typescript@5.9.3):
+    dependencies:
+      '@puppeteer/browsers': 2.13.0
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1581282)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
+      devtools-protocol: 0.0.1581282
+      puppeteer-core: 24.40.0
+      typed-query-selector: 2.12.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - typescript
+      - utf-8-validate
 
   qs@6.14.1:
     dependencies:
@@ -8853,7 +9340,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -8913,6 +9400,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  semver@7.7.4: {}
 
   send@1.2.1:
     dependencies:
@@ -9090,6 +9579,21 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+
   sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -9111,6 +9615,15 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   strict-event-emitter@0.5.1: {}
 
@@ -9238,6 +9751,42 @@ snapshots:
 
   tapable@2.2.2: {}
 
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.8
+    optionalDependencies:
+      bare-fs: 4.7.0
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@3.1.8:
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.7.0
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
+
   tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
@@ -9343,6 +9892,8 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typed-query-selector@2.12.1: {}
+
   typescript-eslint@8.48.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -9443,6 +9994,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webdriver-bidi-protocol@0.4.1: {}
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -9508,6 +10061,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@8.20.0: {}
+
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.0
@@ -9539,6 +10094,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/utils/image-processing.ts
+++ b/utils/image-processing.ts
@@ -1,0 +1,294 @@
+/** Quantize a single pixel value to the nearest available gray level
+ *  e.g. levels=2 → 0 or 255, levels=4 → 0, 85, 170, 256
+ **/
+export const quantizeValue = (value: number, levels: number): number => {
+	const step = 255 / (levels - 1);
+	const quantized = Math.round(value / step) * step;
+	return Math.min(255, Math.max(0, quantized));
+};
+
+/** Quantize each pixel to the nearest gray level with no dithering */
+export const quantize = (grayscale: Uint8Array, levels = 2): Uint8Array => {
+	const result = new Uint8Array(grayscale.length);
+	for (let i = 0; i < grayscale.length; i++) {
+		result[i] = quantizeValue(grayscale[i], levels);
+	}
+	return result;
+};
+
+/** Simple threshold dithering. Pixels below threshold map to black, at or above to white. */
+export const ditherThreshold = (
+	grayscale: Uint8Array,
+	threshold = 128,
+): Uint8Array => {
+	const result = new Uint8Array(grayscale.length);
+	for (let i = 0; i < grayscale.length; i++) {
+		result[i] = grayscale[i] < threshold ? 0 : 255;
+	}
+	return result;
+};
+
+/** Floyd-Steinberg error diffusion dithering */
+export const ditherFloydSteinberg = (
+	grayscale: Uint8Array,
+	width: number,
+	height: number,
+	levels = 2,
+): Uint8Array => {
+	const result = new Uint8Array(grayscale.length);
+	const buffer = new Float32Array(grayscale.length);
+
+	for (let i = 0; i < grayscale.length; i++) {
+		buffer[i] = grayscale[i];
+	}
+
+	for (let y = 0; y < height; y++) {
+		for (let x = 0; x < width; x++) {
+			const index = y * width + x;
+			const oldPixel = buffer[index];
+			const newPixel = quantizeValue(oldPixel, levels);
+			result[index] = newPixel;
+			const error = oldPixel - newPixel;
+
+			if (x + 1 < width) buffer[index + 1] += (error * 7) / 16;
+			if (y + 1 < height && x > 0)
+				buffer[index + width - 1] += (error * 3) / 16;
+			if (y + 1 < height) buffer[index + width] += (error * 5) / 16;
+			if (y + 1 < height && x + 1 < width)
+				buffer[index + width + 1] += (error * 1) / 16;
+		}
+	}
+
+	return result;
+};
+
+/** Atkinson error diffusion dithering */
+export const ditherAtkinson = (
+	grayscale: Uint8Array,
+	width: number,
+	height: number,
+	levels = 2,
+): Uint8Array => {
+	const result = new Uint8Array(grayscale.length);
+	const buffer = new Float32Array(grayscale.length);
+
+	for (let i = 0; i < grayscale.length; i++) {
+		buffer[i] = grayscale[i];
+	}
+
+	for (let y = 0; y < height; y++) {
+		for (let x = 0; x < width; x++) {
+			const index = y * width + x;
+			const oldPixel = buffer[index];
+			const newPixel = quantizeValue(oldPixel, levels);
+			result[index] = newPixel;
+			const error = Math.floor((oldPixel - newPixel) / 8);
+
+			if (x + 1 < width) buffer[index + 1] += error;
+			if (x + 2 < width) buffer[index + 2] += error;
+			if (y + 1 < height && x - 1 >= 0) buffer[index + width - 1] += error;
+			if (y + 1 < height) buffer[index + width] += error;
+			if (y + 1 < height && x + 1 < width) buffer[index + width + 1] += error;
+			if (y + 2 < height) buffer[index + width * 2] += error;
+		}
+	}
+
+	return result;
+};
+
+const BAYER_MATRICES = {
+	2: [
+		[0, 2],
+		[3, 1],
+	],
+	4: [
+		[0, 8, 2, 10],
+		[12, 4, 14, 6],
+		[3, 11, 1, 9],
+		[15, 7, 13, 5],
+	],
+	8: [
+		[0, 32, 8, 40, 2, 34, 10, 42],
+		[48, 16, 56, 24, 50, 18, 58, 26],
+		[12, 44, 4, 36, 14, 46, 6, 38],
+		[60, 28, 52, 20, 62, 30, 54, 22],
+		[3, 35, 11, 43, 1, 33, 9, 41],
+		[51, 19, 59, 27, 49, 17, 57, 25],
+		[15, 47, 7, 39, 13, 45, 5, 37],
+		[63, 31, 55, 23, 61, 29, 53, 21],
+	],
+};
+
+/** Bayer ordered dithering. patternSize selects the matrix: 2, 4, or 8 */
+export const ditherBayer = (
+	grayscale: Uint8Array,
+	width: number,
+	height: number,
+	levels = 2,
+	patternSize = 8,
+): Uint8Array => {
+	const result = new Uint8Array(grayscale.length);
+
+	const matrixSize = patternSize <= 2 ? 2 : patternSize <= 4 ? 4 : 8;
+	const matrix = BAYER_MATRICES[matrixSize];
+	const matrixLength = matrix.length;
+
+	const normalizedMatrix = matrix.map((row) =>
+		row.map((val) => Math.floor((val * 255) / (matrixLength * matrixLength))),
+	);
+
+	for (let y = 0; y < height; y++) {
+		for (let x = 0; x < width; x++) {
+			const index = y * width + x;
+			const gray = grayscale[index];
+			const threshold = normalizedMatrix[y % matrixLength][x % matrixLength];
+			const adjustedValue = gray + (threshold - 128);
+			result[index] = quantizeValue(adjustedValue, levels);
+		}
+	}
+
+	return result;
+};
+
+/** Random noise dithering */
+export const ditherRandom = (grayscale: Uint8Array, levels = 2): Uint8Array => {
+	const result = new Uint8Array(grayscale.length);
+
+	for (let i = 0; i < grayscale.length; i++) {
+		const adjustedValue = grayscale[i] + (Math.random() * 255 - 128);
+		result[i] = quantizeValue(adjustedValue, levels);
+	}
+
+	return result;
+};
+
+/** Detect edge pixels by checking if a pixel or any 4-directional neighbor is near pure black or white.
+ *  Returns a Uint8Array where 1 = edge pixel, 0 = non-edge. Border pixels are always 0. */
+export const detectEdges = (
+	grayscale: Uint8Array,
+	width: number,
+	height: number,
+	fuzziness = 20,
+): Uint8Array => {
+	const result = new Uint8Array(grayscale.length);
+	const limit = 255 - fuzziness;
+
+	for (let y = 1; y < height - 1; y++) {
+		for (let x = 1; x < width - 1; x++) {
+			const idx = y * width + x;
+			const isExtreme = (v: number) => v < fuzziness || v > limit;
+			const hasExtreme =
+				isExtreme(grayscale[idx]) ||
+				isExtreme(grayscale[idx - 1]) ||
+				isExtreme(grayscale[idx + 1]) ||
+				isExtreme(grayscale[idx - width]) ||
+				isExtreme(grayscale[idx + width]);
+			result[idx] = hasExtreme ? 1 : 0;
+		}
+	}
+
+	return result;
+};
+
+/** For edge pixels, snap to the nearest quantized level instead of using the dithered value.
+ *  Non-edge pixels pass through unchanged from the dithered input. */
+export const applyEdgeSnap = (
+	grayscale: Uint8Array,
+	dithered: Uint8Array,
+	edges: Uint8Array,
+	levels = 2,
+): Uint8Array => {
+	const result = new Uint8Array(grayscale.length);
+	for (let i = 0; i < grayscale.length; i++) {
+		result[i] = edges[i] ? quantizeValue(grayscale[i], levels) : dithered[i];
+	}
+	return result;
+};
+
+export enum DitheringMethod {
+	THRESHOLD = "threshold",
+	FLOYD_STEINBERG = "floyd-steinberg",
+	ATKINSON = "atkinson",
+	BAYER = "bayer",
+	RANDOM = "random",
+	NONE = "none",
+}
+
+export interface DitheringOptions {
+	width?: number;
+	height?: number;
+	levels?: number;
+	threshold?: number;
+	applyEdgeSnap?: boolean;
+	edgeDetectionFuzziness?: number;
+	bayerPatternSize?: 2 | 4 | 8;
+}
+
+export function applyDithering(
+	method: DitheringMethod,
+	grayscale: Uint8Array,
+	options: DitheringOptions = {},
+): Uint8Array {
+	const {
+		width,
+		height,
+		levels,
+		threshold,
+		applyEdgeSnap: edgeSnap = false,
+		edgeDetectionFuzziness,
+		bayerPatternSize,
+	} = options;
+
+	const needsDimensions =
+		method === DitheringMethod.FLOYD_STEINBERG ||
+		method === DitheringMethod.ATKINSON ||
+		method === DitheringMethod.BAYER ||
+		edgeSnap;
+
+	if (needsDimensions && (width === undefined || height === undefined)) {
+		throw new Error(`width and height are required for ${method} dithering`);
+	}
+	if (bayerPatternSize !== undefined && ![2, 4, 8].includes(bayerPatternSize)) {
+		throw new Error("bayerPatternSize must be 2, 4, or 8");
+	}
+
+	let result: Uint8Array;
+	switch (method) {
+		case DitheringMethod.THRESHOLD:
+			result = ditherThreshold(grayscale, threshold);
+			break;
+		case DitheringMethod.FLOYD_STEINBERG:
+			result = ditherFloydSteinberg(grayscale, width!, height!, levels);
+			break;
+		case DitheringMethod.ATKINSON:
+			result = ditherAtkinson(grayscale, width!, height!, levels);
+			break;
+		case DitheringMethod.BAYER:
+			result = ditherBayer(
+				grayscale,
+				width!,
+				height!,
+				levels,
+				bayerPatternSize,
+			);
+			break;
+		case DitheringMethod.RANDOM:
+			result = ditherRandom(grayscale, levels);
+			break;
+		case DitheringMethod.NONE:
+			result = quantize(grayscale, levels);
+			break;
+	}
+
+	if (edgeSnap) {
+		const edges = detectEdges(
+			grayscale,
+			width!,
+			height!,
+			edgeDetectionFuzziness,
+		);
+		return applyEdgeSnap(grayscale, result, edges, levels);
+	}
+
+	return result;
+}

--- a/utils/render-bmp.ts
+++ b/utils/render-bmp.ts
@@ -9,6 +9,7 @@ export interface RenderBmpOptions {
 	width?: number;
 	height?: number;
 	grayscale?: number; // Number of gray levels: 2 (black/white), 4, or 16
+	applyEdgeSnap?: boolean;
 }
 
 export async function renderBmp(png: Buffer, options: RenderBmpOptions = {}) {
@@ -16,6 +17,7 @@ export async function renderBmp(png: Buffer, options: RenderBmpOptions = {}) {
 		ditheringMethod = DitheringMethod.FLOYD_STEINBERG,
 		inverted = false,
 		grayscale = 2,
+		applyEdgeSnap = true,
 	} = options;
 
 	// Validate grayscale levels
@@ -62,7 +64,7 @@ export async function renderBmp(png: Buffer, options: RenderBmpOptions = {}) {
 		width: targetWidth,
 		height: targetHeight,
 		levels: grayscale,
-		applyEdgeSnap: true,
+		applyEdgeSnap,
 	});
 
 	// Determine BMP format based on grayscale levels

--- a/utils/render-bmp.ts
+++ b/utils/render-bmp.ts
@@ -1,232 +1,7 @@
 import sharp from "sharp";
+import { DitheringMethod, applyDithering } from "./image-processing";
 
-/** Dithering method options */
-export enum DitheringMethod {
-	FLOYD_STEINBERG = "floyd-steinberg",
-	ATKINSON = "atkinson",
-	BAYER = "bayer",
-	RANDOM = "random",
-}
-
-/** Bayer matrix (8x8) for dithering */
-const BAYER_MATRIX_8x8: number[][] = [
-	[0, 32, 8, 40, 2, 34, 10, 42],
-	[48, 16, 56, 24, 50, 18, 58, 26],
-	[12, 44, 4, 36, 14, 46, 6, 38],
-	[60, 28, 52, 20, 62, 30, 54, 22],
-	[3, 35, 11, 43, 1, 33, 9, 41],
-	[51, 19, 59, 27, 49, 17, 57, 25],
-	[15, 47, 7, 39, 13, 45, 5, 37],
-	[63, 31, 55, 23, 61, 29, 53, 21],
-];
-
-/** Bayer matrices of different sizes */
-const BAYER_MATRICES: Record<number, number[][]> = {
-	2: [
-		[0, 2],
-		[3, 1],
-	],
-	4: [
-		[0, 8, 2, 10],
-		[12, 4, 14, 6],
-		[3, 11, 1, 9],
-		[15, 7, 13, 5],
-	],
-	8: BAYER_MATRIX_8x8,
-};
-
-/**
- * Quantize a value to the nearest available gray level
- */
-const quantizeToLevel = (value: number, levels: number): number => {
-	const step = 255 / (levels - 1);
-	const quantized = Math.round(value / step) * step;
-	return Math.min(255, Math.max(0, quantized));
-};
-
-/**
- * Apply Floyd-Steinberg dithering algorithm
- */
-const applyFloydSteinberg = (
-	grayscale: Uint8Array,
-	width: number,
-	height: number,
-	grayscaleLevels: number = 2,
-	inverted: boolean = false,
-): Uint8Array => {
-	// Create a copy of the grayscale array to avoid modifying the original
-	const result = new Uint8Array(grayscale.length);
-	const buffer = new Float32Array(grayscale.length);
-
-	// Initialize buffer with grayscale values
-	for (let i = 0; i < grayscale.length; i++) {
-		buffer[i] = grayscale[i];
-	}
-
-	// Apply Floyd-Steinberg dithering
-	for (let y = 0; y < height; y++) {
-		for (let x = 0; x < width; x++) {
-			const index = y * width + x;
-			const oldPixel = buffer[index];
-			const newPixel = quantizeToLevel(oldPixel, grayscaleLevels);
-			const finalPixel = inverted ? 255 - newPixel : newPixel;
-			result[index] = finalPixel;
-			const error = oldPixel - newPixel;
-
-			if (x + 1 < width) buffer[index + 1] += (error * 7) / 16;
-			if (y + 1 < height && x > 0)
-				buffer[index + width - 1] += (error * 3) / 16;
-			if (y + 1 < height) buffer[index + width] += (error * 5) / 16;
-			if (y + 1 < height && x + 1 < width)
-				buffer[index + width + 1] += (error * 1) / 16;
-		}
-	}
-
-	return result;
-};
-
-/**
- * Apply Atkinson dithering algorithm
- */
-const applyAtkinson = (
-	grayscale: Uint8Array,
-	width: number,
-	height: number,
-	grayscaleLevels: number = 2,
-	inverted: boolean = false,
-): Uint8Array => {
-	// Create a copy of the grayscale array to avoid modifying the original
-	const result = new Uint8Array(grayscale.length);
-	const buffer = new Float32Array(grayscale.length);
-
-	// Initialize buffer with grayscale values
-	for (let i = 0; i < grayscale.length; i++) {
-		buffer[i] = grayscale[i];
-	}
-
-	// Apply Atkinson dithering
-	for (let y = 0; y < height; y++) {
-		for (let x = 0; x < width; x++) {
-			const index = y * width + x;
-			const oldPixel = buffer[index];
-			const newPixel = quantizeToLevel(oldPixel, grayscaleLevels);
-			const finalPixel = inverted ? 255 - newPixel : newPixel;
-			result[index] = finalPixel;
-			const error = Math.floor((oldPixel - newPixel) / 8);
-
-			if (x + 1 < width) buffer[index + 1] += error;
-			if (x + 2 < width) buffer[index + 2] += error;
-			if (y + 1 < height && x - 1 >= 0) buffer[index + width - 1] += error;
-			if (y + 1 < height) buffer[index + width] += error;
-			if (y + 1 < height && x + 1 < width) buffer[index + width + 1] += error;
-			if (y + 2 < height) buffer[index + width * 2] += error;
-		}
-	}
-
-	return result;
-};
-
-/**
- * Apply Bayer dithering algorithm
- */
-const applyBayer = (
-	grayscale: Uint8Array,
-	width: number,
-	height: number,
-	grayscaleLevels: number = 2,
-	patternSize: number = 8,
-	inverted: boolean = false,
-): Uint8Array => {
-	const result = new Uint8Array(grayscale.length);
-
-	// Use the closest available matrix size
-	const matrixSize = patternSize <= 2 ? 2 : patternSize <= 4 ? 4 : 8;
-	const matrix = BAYER_MATRICES[matrixSize];
-	const matrixLength = matrix.length;
-
-	// Normalize the matrix values to 0-255 range
-	const normalizedMatrix = matrix.map((row) =>
-		row.map((val) => Math.floor((val * 255) / (matrixLength * matrixLength))),
-	);
-
-	// Apply Bayer dithering
-	for (let y = 0; y < height; y++) {
-		for (let x = 0; x < width; x++) {
-			const index = y * width + x;
-			const gray = grayscale[index];
-			const matrixX = x % matrixLength;
-			const matrixY = y % matrixLength;
-			const threshold = normalizedMatrix[matrixY][matrixX];
-
-			// Apply threshold and quantize to nearest level
-			const adjustedValue = gray + (threshold - 128);
-			const quantizedValue = quantizeToLevel(adjustedValue, grayscaleLevels);
-			result[index] = inverted ? 255 - quantizedValue : quantizedValue;
-		}
-	}
-
-	return result;
-};
-
-/**
- * Apply random dithering
- */
-const applyRandom = (
-	grayscale: Uint8Array,
-	_width: number,
-	_height: number,
-	grayscaleLevels: number = 2,
-	inverted: boolean = false,
-): Uint8Array => {
-	const result = new Uint8Array(grayscale.length);
-
-	for (let i = 0; i < grayscale.length; i++) {
-		const gray = grayscale[i];
-		const randomThreshold = Math.random() * 255;
-		const adjustedValue = gray + (randomThreshold - 128);
-		const quantizedValue = quantizeToLevel(adjustedValue, grayscaleLevels);
-		result[i] = inverted ? 255 - quantizedValue : quantizedValue;
-	}
-
-	return result;
-};
-
-/**
- * Apply the specified dithering method to the grayscale image
- */
-const applyDithering = (
-	grayscale: Uint8Array,
-	width: number,
-	height: number,
-	method: DitheringMethod = DitheringMethod.FLOYD_STEINBERG,
-	grayscaleLevels: number = 2,
-	inverted: boolean = false,
-): Uint8Array => {
-	switch (method) {
-		case DitheringMethod.FLOYD_STEINBERG:
-			return applyFloydSteinberg(
-				grayscale,
-				width,
-				height,
-				grayscaleLevels,
-				inverted,
-			);
-		case DitheringMethod.ATKINSON:
-			return applyAtkinson(grayscale, width, height, grayscaleLevels, inverted);
-		case DitheringMethod.BAYER:
-			return applyBayer(grayscale, width, height, grayscaleLevels, 8, inverted);
-		case DitheringMethod.RANDOM:
-			return applyRandom(grayscale, width, height, grayscaleLevels, inverted);
-		default:
-			return applyFloydSteinberg(
-				grayscale,
-				width,
-				height,
-				grayscaleLevels,
-				inverted,
-			);
-	}
-};
+export { DitheringMethod };
 
 export interface RenderBmpOptions {
 	ditheringMethod?: DitheringMethod;
@@ -240,7 +15,7 @@ export async function renderBmp(png: Buffer, options: RenderBmpOptions = {}) {
 	const {
 		ditheringMethod = DitheringMethod.FLOYD_STEINBERG,
 		inverted = false,
-		grayscale = 2, // Default to 2 levels (black/white)
+		grayscale = 2,
 	} = options;
 
 	// Validate grayscale levels
@@ -274,58 +49,21 @@ export async function renderBmp(png: Buffer, options: RenderBmpOptions = {}) {
 		.raw()
 		.toBuffer({ resolveWithObject: true });
 
-	const { data } = grayscaleImage; // `data` is a Uint8Array of grayscale values
+	const { data } = grayscaleImage;
 
-	// Step 2: Process the grayscale image
+	// Step 2: Copy grayscale data
 	const grayscaleData = new Uint8Array(targetPixelCount);
-	const isEdge = new Uint8Array(targetPixelCount);
-
-	// First, copy grayscale data
-	for (let y = 0; y < targetHeight; y++) {
-		for (let x = 0; x < targetWidth; x++) {
-			const i = y * targetWidth + x;
-			grayscaleData[i] = data[i] as number;
-		}
+	for (let i = 0; i < targetPixelCount; i++) {
+		grayscaleData[i] = data[i] as number;
 	}
 
-	// Step 3: Edge detection
-	for (let y = 0; y < targetHeight; y++) {
-		const yOffset = y * targetWidth;
-
-		for (let x = 0; x < targetWidth; x++) {
-			const idx = yOffset + x;
-			const gray = grayscaleData[idx];
-
-			// Edge detection for pixels not on the border
-			if (y > 0 && y < targetHeight - 1 && x > 0 && x < targetWidth - 1) {
-				// Check if this pixel has high contrast with neighbors
-				const fuzziness = 20;
-				const hasExtreme =
-					gray < fuzziness ||
-					gray > 255 - fuzziness ||
-					grayscaleData[idx - 1] < fuzziness ||
-					grayscaleData[idx - 1] > 255 - fuzziness ||
-					grayscaleData[idx + 1] < fuzziness ||
-					grayscaleData[idx + 1] > 255 - fuzziness ||
-					grayscaleData[idx - targetWidth] < fuzziness ||
-					grayscaleData[idx - targetWidth] > 255 - fuzziness ||
-					grayscaleData[idx + targetWidth] < fuzziness ||
-					grayscaleData[idx + targetWidth] > 255 - fuzziness;
-
-				isEdge[idx] = hasExtreme ? 1 : 0;
-			}
-		}
-	}
-
-	// Step 4: Apply the selected dithering method (with quantization to target gray levels)
-	const dithered = applyDithering(
-		grayscaleData,
-		targetWidth,
-		targetHeight,
-		ditheringMethod,
-		grayscale,
-		inverted,
-	);
+	// Step 3: Apply dithering with edge snapping
+	const dithered = applyDithering(ditheringMethod, grayscaleData, {
+		width: targetWidth,
+		height: targetHeight,
+		levels: grayscale,
+		applyEdgeSnap: true,
+	});
 
 	// Determine BMP format based on grayscale levels
 	const bitsPerPixel = grayscale === 2 ? 1 : grayscale === 4 ? 2 : 4;
@@ -342,13 +80,13 @@ export async function renderBmp(png: Buffer, options: RenderBmpOptions = {}) {
 	// Create a buffer of exactly the required size
 	const buffer = Buffer.alloc(fileSize);
 
-	// BMP File Header - matching firmware expectations
+	// BMP File Header
 	buffer.write("BM", 0); // Signature
 	buffer.writeUInt32LE(fileSize, 2); // File Size
 	buffer.writeUInt32LE(0, 6); // Reserved
 	buffer.writeUInt32LE(fileHeaderSize + infoHeaderSize + paletteSize, 10); // Pixel data offset
 
-	// BMP Info Header - matching firmware expectations
+	// BMP Info Header
 	buffer.writeUInt32LE(infoHeaderSize, 14); // Info Header Size
 	buffer.writeInt32LE(targetWidth, 18); // Width
 	buffer.writeInt32LE(targetHeight, 22); // Height
@@ -366,26 +104,21 @@ export async function renderBmp(png: Buffer, options: RenderBmpOptions = {}) {
 	const paletteOffset = fileHeaderSize + infoHeaderSize;
 	const paletteStep = 255 / (grayscale - 1);
 	for (let i = 0; i < grayscale; i++) {
-		// Generate from white (255) to black (0)
 		const grayValue = Math.round(255 - i * paletteStep);
-		// BMP palette format: BGR + reserved byte (0x00)
 		const paletteEntry = (grayValue << 16) | (grayValue << 8) | grayValue;
 		buffer.writeUInt32LE(paletteEntry, paletteOffset + i * 4);
 	}
 
-	// Step 6: Generate the final bitmap
+	// Map a quantized grayscale value (0-255) to a palette index
+	// Palette: index 0 = white (255), index N-1 = black (0)
+	const valueToIndex = (value: number): number =>
+		grayscale - 1 - Math.round(value / paletteStep);
+
+	// Step 4: Generate the final bitmap
 	const dataOffset = fileHeaderSize + infoHeaderSize + paletteSize;
 
-	// Create a mapping function from quantized grayscale value to palette index
-	// Palette: index 0 = white (255), index N-1 = black (0)
-	const valueToIndex = (value: number): number => {
-		// Map from 0-255 to palette index (0 = white, N-1 = black)
-		return grayscale - 1 - Math.round(value / paletteStep);
-	};
-
-	// Process pixels based on bit depth
 	for (let y = 0; y < targetHeight; y++) {
-		// BMP is stored bottom-up, so we need to flip the y-coordinate
+		// BMP is stored bottom-up
 		const targetY = targetHeight - 1 - y;
 		const yOffset = targetY * targetWidth;
 		const destRowOffset = dataOffset + y * rowSize;
@@ -395,40 +128,12 @@ export async function renderBmp(png: Buffer, options: RenderBmpOptions = {}) {
 			for (let x = 0; x < targetWidth; x += 8) {
 				let byte = 0;
 				const remainingPixels = Math.min(8, targetWidth - x);
-
 				for (let bit = 0; bit < remainingPixels; bit++) {
-					const pixelX = x + bit;
-					const idx = yOffset + pixelX;
-					const ditheredValue = dithered[idx];
-					const gray = grayscaleData[idx];
-					let paletteIndex = valueToIndex(ditheredValue);
-
-					if (gray < 10) {
-						// Pure black pixel
-						paletteIndex = 1;
-					} else if (gray > 240) {
-						// Pure white pixel
-						paletteIndex = 0;
-					} else if (isEdge[idx]) {
-						// On an edge (likely text) - round to black for better contrast
-						paletteIndex = gray < 128 ? 1 : 0;
-					} else {
-						// Not on an edge (likely in an image) - use dithered result
-						paletteIndex = ditheredValue < 128 ? 1 : 0; // Values are either 0 or 255
-					}
-
-					// Invert if needed
-					if (inverted) {
-						paletteIndex = grayscale - 1 - paletteIndex;
-					}
-
-					// For 1-bit, palette index 1 = black, index 0 = white
-					// Set bit to 1 if palette index is 1 (black)
-					if (paletteIndex === grayscale - 1) {
-						byte |= 1 << (7 - bit);
-					}
+					const idx = yOffset + x + bit;
+					let paletteIndex = valueToIndex(dithered[idx]);
+					if (inverted) paletteIndex = grayscale - 1 - paletteIndex;
+					if (paletteIndex === grayscale - 1) byte |= 1 << (7 - bit);
 				}
-
 				buffer[destRowOffset + (x >> 3)] = byte;
 			}
 		} else if (bitsPerPixel === 2) {
@@ -436,37 +141,12 @@ export async function renderBmp(png: Buffer, options: RenderBmpOptions = {}) {
 			for (let x = 0; x < targetWidth; x += 4) {
 				let byte = 0;
 				const remainingPixels = Math.min(4, targetWidth - x);
-
 				for (let bit = 0; bit < remainingPixels; bit++) {
-					const pixelX = x + bit;
-					const idx = yOffset + pixelX;
-					const ditheredValue = dithered[idx];
-					const gray = grayscaleData[idx];
-					let paletteIndex = valueToIndex(ditheredValue);
-
-					if (gray < 10) {
-						// Pure black pixel
-						paletteIndex = grayscale - 1;
-					} else if (gray > 240) {
-						// Pure white pixel
-						paletteIndex = 0;
-					} else if (isEdge[idx]) {
-						// On an edge (likely text) - round to black or white for better contrast
-						paletteIndex = gray < 128 ? grayscale - 1 : 0;
-					} else {
-						// Not on an edge (likely in an image) - use dithered result
-						paletteIndex = valueToIndex(ditheredValue);
-					}
-
-					// Invert if needed
-					if (inverted) {
-						paletteIndex = grayscale - 1 - paletteIndex;
-					}
-
-					// Pack 2 bits per pixel (bits 7-6, 5-4, 3-2, 1-0)
+					const idx = yOffset + x + bit;
+					let paletteIndex = valueToIndex(dithered[idx]);
+					if (inverted) paletteIndex = grayscale - 1 - paletteIndex;
 					byte |= paletteIndex << (6 - bit * 2);
 				}
-
 				buffer[destRowOffset + (x >> 2)] = byte;
 			}
 		} else if (bitsPerPixel === 4) {
@@ -474,37 +154,12 @@ export async function renderBmp(png: Buffer, options: RenderBmpOptions = {}) {
 			for (let x = 0; x < targetWidth; x += 2) {
 				let byte = 0;
 				const remainingPixels = Math.min(2, targetWidth - x);
-
 				for (let bit = 0; bit < remainingPixels; bit++) {
-					const pixelX = x + bit;
-					const idx = yOffset + pixelX;
-					const ditheredValue = dithered[idx];
-					const gray = grayscaleData[idx];
-					let paletteIndex = valueToIndex(ditheredValue);
-
-					if (gray < 10) {
-						// Pure black pixel
-						paletteIndex = grayscale - 1;
-					} else if (gray > 240) {
-						// Pure white pixel
-						paletteIndex = 0;
-					} else if (isEdge[idx]) {
-						// On an edge (likely text) - round to black or white for better contrast
-						paletteIndex = gray < 128 ? grayscale - 1 : 0;
-					} else {
-						// Not on an edge (likely in an image) - use dithered result
-						paletteIndex = valueToIndex(ditheredValue);
-					}
-
-					// Invert if needed
-					if (inverted) {
-						paletteIndex = grayscale - 1 - paletteIndex;
-					}
-
-					// Pack 4 bits per pixel (bits 7-4 for first pixel, 3-0 for second)
+					const idx = yOffset + x + bit;
+					let paletteIndex = valueToIndex(dithered[idx]);
+					if (inverted) paletteIndex = grayscale - 1 - paletteIndex;
 					byte |= paletteIndex << (4 - bit * 4);
 				}
-
 				buffer[destRowOffset + (x >> 1)] = byte;
 			}
 		}


### PR DESCRIPTION
This PR introduces browser-based rendering using Puppeteer/Chrome, enabling server-side rendering of React components through a real browser engine. This is especially useful for complex layouts that takumi/satori struggle with.

## Features
### Browser Renderer (`lib/recipes/renderers/browser.ts`)
- New rendering backend via `REACT_RENDERER=browser`
- Supports multiple Chrome connection methods:
  - `BROWSER_URL` – remote Chrome container
  - `BROWSER_WS_ENDPOINT` – WebSocket endpoint  
  - `CHROME_EXECUTABLE_PATH` – local Chrome binary
  - Bundled Chrome (via `puppeteer`) – default if none specified
- Optional dependency – only loads when browser rendering is configured
### Authentication Cookie Forwarding
- Extracts session cookies from incoming bitmap API requests
- Forwards to Puppeteer via `page.setCookie()` with proper domain matching
- Enables authenticated routes to render correctly
### Docker Support
- `docker-compose.browser.yml` – Chrome container using `zenika/alpine-chrome`
- Run: `docker compose -f docker-compose.yml -f docker-compose.browser.yml up`
### Refactored Architecture
- Split monolithic renderer into separate modules: `takumi.ts`, `satori.ts`, `browser.ts`
- `renderRecipeOutputs()` now accepts an optional `cookies` parameter for browser auth
- Backward compatible – existing takumi/satori renderers work unchanged
- Centralized dithering – consolidated multiple implementations into a single shared module (`utils/image-processing.ts`)
- Per-recipe edge snap control – `applyEdgeSnap` can now be disabled per recipe via `renderSettings.applyEdgeSnap` (defaults to `true`)
- Color consistency – updated recipes to use explicit `text-black`. Tailwind default text is dark grey but takumi/satori was pure black, which affected dithering behavior

## Configuration
```bash
# Required
REACT_RENDERER=browser
# Connection method (optional - defaults to bundled puppeteer)
BROWSER_URL=http://127.0.0.1:9222               # Remote Chrome
BROWSER_WS_ENDPOINT=ws://...                    # WebSocket
CHROME_EXECUTABLE_PATH=/usr/bin/google-chrome   # Local Chrome
# Optional
NEXT_PUBLIC_BASE_URL=http://localhost:3000
```
## Testing
1. `pnpm add puppeteer` or `puppeteer-core` for remote Chrome
2. Set REACT_RENDERER=browser
3. Log in to the app
4. Visit /api/bitmap/{recipe}.bmp

## Next Steps
Framework UI support coming in a follow-up PR to keep review scope manageable.