### PR TITLE
fix(migrations): make RLS init portable across Postgres providers (Neon, Supabase, Vercel)

### DIFF
--- a/lib/database/sql-statements.ts
+++ b/lib/database/sql-statements.ts
@@ -391,11 +391,20 @@ $$;
 -- Ensure the role does NOT have BYPASSRLS (default, but explicit for clarity)
 ALTER ROLE byos_app NOBYPASSRLS;
 
--- Allow postgres to switch to this role via SET ROLE
-GRANT byos_app TO postgres;
+-- Allow the connecting role (whatever it is — postgres, neondb_owner, supabase_admin, etc.)
+-- to switch to byos_app via SET ROLE. Using CURRENT_USER makes this portable across providers.
+DO $$
+BEGIN
+    EXECUTE format('GRANT byos_app TO %I', CURRENT_USER);
+END
+$$;
 
--- Grant connect to database
-GRANT CONNECT ON DATABASE byos_db TO byos_app;
+-- Grant connect to the current database (name varies by provider: byos_db, neondb, postgres, etc.)
+DO $$
+BEGIN
+    EXECUTE format('GRANT CONNECT ON DATABASE %I TO byos_app', current_database());
+END
+$$;
 
 -- Grant usage on schema
 GRANT USAGE ON SCHEMA public TO byos_app;

--- a/migrations/0009_add_user_tenancy.sql
+++ b/migrations/0009_add_user_tenancy.sql
@@ -129,11 +129,20 @@ $$;
 -- Ensure the role does NOT have BYPASSRLS (default, but explicit for clarity)
 ALTER ROLE byos_app NOBYPASSRLS;
 
--- Allow postgres to switch to this role via SET ROLE
-GRANT byos_app TO postgres;
+-- Allow the connecting role (whatever it is — postgres, neondb_owner, supabase_admin, etc.)
+-- to switch to byos_app via SET ROLE. Using CURRENT_USER makes this portable across providers.
+DO $$
+BEGIN
+    EXECUTE format('GRANT byos_app TO %I', CURRENT_USER);
+END
+$$;
 
--- Grant connect to database
-GRANT CONNECT ON DATABASE byos_db TO byos_app;
+-- Grant connect to the current database (name varies by provider: byos_db, neondb, postgres, etc.)
+DO $$
+BEGIN
+    EXECUTE format('GRANT CONNECT ON DATABASE %I TO byos_app', current_database());
+END
+$$;
 
 -- Grant usage on schema
 GRANT USAGE ON SCHEMA public TO byos_app;


### PR DESCRIPTION
## Summary
- Migration `0009_add_user_tenancy.sql` (and the in-app initializer in `lib/database/sql-statements.ts`) hardcoded `GRANT byos_app TO postgres` and `GRANT CONNECT ON DATABASE byos_db`, which fails on managed providers where the connecting role and database name differ.
- Neon, for example, connects as `neondb_owner` to a database named `neondb`, so the init script aborts with `ERROR: role "postgres" does not exist`.
- Replaced both statements with `DO $$ ... EXECUTE format(...) ... $$` blocks that resolve the role via `CURRENT_USER` and the database name via `current_database()`.

## Why
Reported in #46 — Vercel + Neon deploy via the README "Deploy to Vercel" button + in-app **Initialize my database for me** button fails at this step. Same issue would surface on any provider that doesn't expose a literal `postgres` role.

## Behavior after the fix
| Provider | Connecting role | Database | Works? |
|---|---|---|---|
| Local Docker | `postgres` | `byos_db` | ✅ |
| Neon | `neondb_owner` | `neondb` | ✅ |
| Supabase | `postgres` | `postgres` | ✅ |
| Vercel Postgres (Neon-backed) | varies | varies | ✅ |

No schema change, no behavioral change for existing local installs — just removes the hardcoded role/db assumption.

## Test plan
- [x] Re-ran 0009 against local Docker Postgres (role `postgres`, db `byos_db`) — succeeds, RLS still enforced.
- [ ] Verify on a fresh Vercel + Neon deploy by clicking **Initialize my database for me** end-to-end.
- [ ] Verify on Supabase (the connecting role is `postgres` so this should be a no-op regression check).

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)