### PR TITLE
feat(devices): add OG temperature_profile

### DIFF
--- a/app/(app)/device/[friendly_id]/client-page.tsx
+++ b/app/(app)/device/[friendly_id]/client-page.tsx
@@ -283,6 +283,7 @@ export default function DeviceClientPage({
 				screen_height: editedDevice.screen_height,
 				screen_orientation: editedDevice.screen_orientation,
 				grayscale: editedDevice.grayscale,
+				temperature_profile: editedDevice.temperature_profile,
 			});
 
 			if (result.success) {

--- a/app/actions/device.ts
+++ b/app/actions/device.ts
@@ -221,6 +221,8 @@ export async function updateDevice(
 	if (device.screen_orientation !== undefined)
 		updateData.screen_orientation = device.screen_orientation;
 	if (device.grayscale !== undefined) updateData.grayscale = device.grayscale;
+	if (device.temperature_profile !== undefined)
+		updateData.temperature_profile = device.temperature_profile;
 
 	updateData.updated_at = new Date().toISOString();
 

--- a/app/api/display/route.ts
+++ b/app/api/display/route.ts
@@ -196,6 +196,9 @@ export async function GET(request: Request) {
 			// portrait-native, so a landscape orientation needs a 90° rotation.
 			// 0 = portrait (no rotation), 1 = landscape (90°).
 			image_rotate: orientation === "landscape" ? 1 : 0,
+			// Display tuning profile. Firmware reads this only when it sent
+			// `temperature-profile: true` in the request.
+			temperature_profile: device.temperature_profile ?? "default",
 		};
 
 		if (

--- a/app/api/display/utils.ts
+++ b/app/api/display/utils.ts
@@ -29,6 +29,7 @@ export interface RequestHeaders {
 	model: string | null;
 	specialFunction: boolean;
 	base64: boolean;
+	supportsTemperatureProfile: boolean;
 	hostUrl: string;
 }
 
@@ -51,6 +52,7 @@ export const parseRequestHeaders = (request: Request): RequestHeaders => {
 		model: headers.get("Model")?.trim() || null,
 		specialFunction: headers.get("Special-Function") === "true",
 		base64: headers.get("BASE64") === "true",
+		supportsTemperatureProfile: headers.get("temperature-profile") === "true",
 		hostUrl:
 			(headers.get("x-forwarded-proto") || "http") +
 			"://" +
@@ -270,6 +272,7 @@ export const updateDeviceStatus = async (
 	if (device.timezone) {
 		updateData.timezone = device.timezone;
 	}
+	updateData.supports_temperature_profile = headers.supportsTemperatureProfile;
 
 	try {
 		await db

--- a/components/device/device-edit-form.tsx
+++ b/components/device/device-edit-form.tsx
@@ -532,6 +532,28 @@ export default function DeviceEditForm({
 									<ToggleGroupItem value="16">16</ToggleGroupItem>
 								</ToggleGroup>
 							</Field>
+
+							{editedDevice.supports_temperature_profile && (
+								<Field
+									label="Temperature profile"
+									hint="Try A then B if the display looks washed out."
+								>
+									<ToggleGroup
+										type="single"
+										value={editedDevice.temperature_profile ?? "default"}
+										onValueChange={(value) => {
+											if (value) onSelectChange("temperature_profile", value);
+										}}
+										variant="outline"
+										className="grid w-fit grid-cols-4"
+									>
+										<ToggleGroupItem value="default">Default</ToggleGroupItem>
+										<ToggleGroupItem value="a">A</ToggleGroupItem>
+										<ToggleGroupItem value="b">B</ToggleGroupItem>
+										<ToggleGroupItem value="c">C</ToggleGroupItem>
+									</ToggleGroup>
+								</Field>
+							)}
 						</TabsContent>
 
 						<TabsContent value="refresh" className="mt-4 space-y-4">

--- a/lib/database/db.d.ts
+++ b/lib/database/db.d.ts
@@ -111,6 +111,14 @@ export interface Devices {
 	 * Screen width in pixels
 	 */
 	screen_width: Generated<number | null>;
+	/**
+	 * TRUE when the device sent the `temperature-profile: true` request header on its last /api/display call. NULL until the device has been seen.
+	 */
+	supports_temperature_profile: Generated<boolean | null>;
+	/**
+	 * Display tuning profile sent to the firmware in the /api/display response (default|a|b|c).
+	 */
+	temperature_profile: Generated<string>;
 	timezone: Generated<string>;
 	updated_at: Generated<Timestamp | null>;
 	user_id: string | null;

--- a/lib/database/sql-statements.ts
+++ b/lib/database/sql-statements.ts
@@ -928,6 +928,30 @@ CREATE POLICY mixup_slots_delete_policy ON mixup_slots
 GRANT SELECT, INSERT, UPDATE, DELETE ON playlist_items TO byos_app;
 GRANT SELECT, INSERT, UPDATE, DELETE ON mixup_slots TO byos_app;`,
 	},
+	"0015_add_device_temperature_profile": {
+		title: "Add Device Temperature Profile",
+		description:
+			"Per-device color/shadow tuning profile sent back to the firmware",
+		sql: `-- on /api/display as \`temperature_profile\`. Firmware advertises support via the
+-- \`temperature-profile: true\` request header; we cache that capability flag so
+-- the UI can decide whether to expose the setting.
+
+ALTER TABLE devices
+ADD COLUMN IF NOT EXISTS temperature_profile TEXT NOT NULL DEFAULT 'default';
+
+ALTER TABLE devices
+DROP CONSTRAINT IF EXISTS devices_temperature_profile_check;
+
+ALTER TABLE devices
+ADD CONSTRAINT devices_temperature_profile_check
+CHECK (temperature_profile IN ('default', 'a', 'b', 'c'));
+
+ALTER TABLE devices
+ADD COLUMN IF NOT EXISTS supports_temperature_profile BOOLEAN;
+
+COMMENT ON COLUMN devices.temperature_profile IS 'Display tuning profile sent to the firmware in the /api/display response (default|a|b|c).';
+COMMENT ON COLUMN devices.supports_temperature_profile IS 'TRUE when the device sent the \`temperature-profile: true\` request header on its last /api/display call. NULL until the device has been seen.';`,
+	},
 	validate_schema: {
 		title: "Validate Database Schema",
 		description:

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -47,7 +47,11 @@ export type Device = {
 	grayscale: number | null;
 	model: string | null;
 	palette_id: string | null;
+	temperature_profile: TemperatureProfile;
+	supports_temperature_profile: boolean | null;
 };
+
+export type TemperatureProfile = "default" | "a" | "b" | "c";
 
 export type Playlist = {
 	id: string;

--- a/migrations/0015_add_device_temperature_profile.sql
+++ b/migrations/0015_add_device_temperature_profile.sql
@@ -1,0 +1,21 @@
+-- Title: Add Device Temperature Profile
+-- Description: Per-device color/shadow tuning profile sent back to the firmware
+-- on /api/display as `temperature_profile`. Firmware advertises support via the
+-- `temperature-profile: true` request header; we cache that capability flag so
+-- the UI can decide whether to expose the setting.
+
+ALTER TABLE devices
+ADD COLUMN IF NOT EXISTS temperature_profile TEXT NOT NULL DEFAULT 'default';
+
+ALTER TABLE devices
+DROP CONSTRAINT IF EXISTS devices_temperature_profile_check;
+
+ALTER TABLE devices
+ADD CONSTRAINT devices_temperature_profile_check
+CHECK (temperature_profile IN ('default', 'a', 'b', 'c'));
+
+ALTER TABLE devices
+ADD COLUMN IF NOT EXISTS supports_temperature_profile BOOLEAN;
+
+COMMENT ON COLUMN devices.temperature_profile IS 'Display tuning profile sent to the firmware in the /api/display response (default|a|b|c).';
+COMMENT ON COLUMN devices.supports_temperature_profile IS 'TRUE when the device sent the `temperature-profile: true` request header on its last /api/display call. NULL until the device has been seen.';


### PR DESCRIPTION
Hi!

I'm running BYOS_next locally for my OG. Recently, my display started to look pretty washed out after I set up a custom recipe using 2-bit images. I found [this TRMNL help article](https://help.trmnl.com/en/articles/12566040-tuning-a-washed-out-display) on temperature profiles, but that was implemented in Terminus only.

I asked Claude to dig into the firmware to figure out how we can actually do that ourselves, and it found that: 

> The firmware (1.7.x+) advertises support via a temperature-profile: true request header on /api/display, and expects the server to return a temperature_profile field (default / a / b / c) which it maps to an internal index.

So I asked it to add the feature to my local BYOS_next instance. And it worked! I had a new option to change the temperature profile in the "display" tab, I was able to pick a new profile, and as the article said, my screen wasn't washed out anymore ! 

Anyway, I figured I'd open a PR, in case it can help anyone else.

- It adds a couple fields in the DB: `supports_temperature_profile` and `temperature_profile`.
- It adds a new `Temperature Profile` control in the `Display` tab.
- The control won't show for any device at first
- After the next device's refresh (when it calls `/api/display`). if the request carries `temperature-profile: true` in its header, the db is updated and the control is available.

<img width="655" height="622" alt="temp-profile-settings" src="https://github.com/user-attachments/assets/41285481-c268-42a8-acbe-dd72657fcab2" />
