### PR TITLE
fix(firmware): don't advertise unreachable OTA updates

### DIFF
--- a/lib/firmware.ts
+++ b/lib/firmware.ts
@@ -94,6 +94,13 @@ export async function getLatestFirmware(): Promise<FirmwareRelease | null> {
 			publishedAt: data.published_at || new Date().toISOString(),
 		};
 
+		// Don't offer an update the device can't download: variant-partitioned
+		// buckets 404 the flat FW{version}.bin path, reboot-looping devices.
+		const reachable = await fetch(release.downloadUrl, { method: "HEAD" })
+			.then((r) => r.ok)
+			.catch(() => false);
+		if (!reachable) return null;
+
 		// Update cache
 		cachedRelease = release;
 		cacheTime = now;


### PR DESCRIPTION
`getFirmwareUrl()` builds `${CDN}/FW${version}.bin`, but binaries live under per-variant prefixes (`trmnl_og/`, `trmnl_x/`, …), so the URL 404s. `/api/display` advertises it anyway — to first-party **and** BYOD devices (e.g. Seeed E1001) that have no build here — so the device downloads → fails → reboots → loops (~every 3s).

`getLatestFirmware()` now HEAD-checks the URL and returns `null` if unreachable, so a missing/broken build is never advertised. Self-heals once variant-aware URLs land.