### PR TITLE
fix(playlists): don't crash editor when deleting the last frame

### DIFF
--- a/components/playlists/playlist-live-preview.tsx
+++ b/components/playlists/playlist-live-preview.tsx
@@ -31,7 +31,10 @@ export function PlaylistLivePreview({
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [progress, setProgress] = useState(0);
 
-	const active = frames[activeIndex];
+	// Deleting the last/selected frame leaves activeIndex out of bounds for one
+	// render (parent clamps it via effect afterwards); fall back to the last
+	// frame so we never deref undefined and crash the editor.
+	const active = frames[activeIndex] ?? frames[frames.length - 1];
 	const duration = Math.max(1, active?.duration ?? 30);
 	const isEmpty = frames.length === 0;
 


### PR DESCRIPTION
Deleting the last/selected frame leaves `activeIndex` out of bounds for one render (the parent clamps it via effect afterwards). `PlaylistLivePreview` only guards `frames.length === 0`, so it derefs `active.id`/`screen_id`/`label` on `undefined` and crashes the editor (error boundary).

Fall back to the last frame when the index is momentarily out of bounds.