### PR TITLE
fix: restore dashboard bitmap preview profile

### DIFF
--- a/app/(app)/client-page.tsx
+++ b/app/(app)/client-page.tsx
@@ -15,13 +15,13 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
-import {
-	DEFAULT_IMAGE_HEIGHT,
-	DEFAULT_IMAGE_WIDTH,
-} from "@/lib/recipes/constants";
+import { normalizeGrayscale } from "@/lib/trmnl/grayscale";
+import { DEFAULT_MODEL_NAME } from "@/lib/trmnl/types";
 import type { Device, SystemLog } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { formatDate, getDeviceStatus } from "@/utils/helpers";
+
+const DEFAULT_SCREEN = "simple-text";
 
 interface DashboardClientPageProps {
 	devices: Device[];
@@ -50,12 +50,9 @@ export default function DashboardClientPage({
 			: null;
 
 	const isPortrait = lastUpdatedDevice?.screen_orientation === "portrait";
-	const deviceWidth = isPortrait
-		? lastUpdatedDevice?.screen_height || DEFAULT_IMAGE_HEIGHT
-		: lastUpdatedDevice?.screen_width || DEFAULT_IMAGE_WIDTH;
-	const deviceHeight = isPortrait
-		? lastUpdatedDevice?.screen_width || DEFAULT_IMAGE_WIDTH
-		: lastUpdatedDevice?.screen_height || DEFAULT_IMAGE_HEIGHT;
+	const latestScreenSrc = lastUpdatedDevice
+		? buildLatestScreenSrc(lastUpdatedDevice)
+		: "";
 
 	return (
 		<div className="space-y-4">
@@ -94,7 +91,7 @@ export default function DashboardClientPage({
 							>
 								<DeviceFrame size="lg" portrait={isPortrait}>
 									<Image
-										src={`/api/bitmap/${lastUpdatedDevice.screen}.bmp?width=${deviceWidth}&height=${deviceHeight}`}
+										src={latestScreenSrc}
 										alt={`${lastUpdatedDevice.name} screen`}
 										fill
 										className="absolute inset-0 h-full w-full object-cover"
@@ -236,6 +233,19 @@ export default function DashboardClientPage({
 			</section>
 		</div>
 	);
+}
+
+function buildLatestScreenSrc(device: Device): string {
+	const params = new URLSearchParams({
+		grayscale: String(normalizeGrayscale(device.grayscale)),
+		model: device.model?.trim() || DEFAULT_MODEL_NAME,
+	});
+	const paletteId = device.palette_id?.trim();
+	if (paletteId) {
+		params.set("palette_id", paletteId);
+	}
+
+	return `/api/bitmap/${device.screen || DEFAULT_SCREEN}.png?${params.toString()}`;
 }
 
 function Stat({


### PR DESCRIPTION
## Summary
- Stop the dashboard latest-screen preview from forcing saved device width/height into `/api/bitmap` requests.
- Request the preview with the device render profile (`model`, `palette_id`, and grayscale), matching the newer recipe/device preview paths.
- Fall back to `simple-text` when a device has no selected screen.

## Test plan
- `pnpm typecheck`
- `pnpm lint`


Made with [Cursor](https://cursor.com)