### PR TITLE
Fix release cache cleanup failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: ".node-version"
-          cache: "pnpm"
 
       - name: Detect version context
         id: version


### PR DESCRIPTION
## Summary
- Remove pnpm caching from the release job's Node setup because that job does not install dependencies.
- Avoid setup-node failing during post-job cache cleanup when the pnpm store path is absent.

## Test plan
- Parsed `.github/workflows/release.yml` as YAML.
- Ran `git diff --check -- .github/workflows/release.yml`.